### PR TITLE
Handle single column tables

### DIFF
--- a/sqlsynthgen/make.py
+++ b/sqlsynthgen/make.py
@@ -62,9 +62,9 @@ def make_generators_from_tables(tables_module: ModuleType) -> str:
         for column in table.columns:
             # We presume that primary keys are populated automatically
             if column.primary_key:
-                continue
+                new_content += f"{INDENTATION*2}pass\n"
 
-            if column.foreign_keys:
+            elif column.foreign_keys:
                 if len(column.foreign_keys) > 1:
                     raise NotImplementedError("Can't handle multiple foreign keys.")
                 fkey = column.foreign_keys.pop()
@@ -76,8 +76,8 @@ def make_generators_from_tables(tables_module: ModuleType) -> str:
                     f'"{fk_schema}", "{fk_table}", "{fk_column}"'
                     ")\n"
                 )
-            else:
 
+            else:
                 new_content += (
                     INDENTATION * 2
                     + "self."

--- a/sqlsynthgen/make.py
+++ b/sqlsynthgen/make.py
@@ -38,12 +38,14 @@ def make_generators_from_tables(tables_module: ModuleType) -> str:
     sql_to_mimesis_map = {
         sqltypes.BigInteger: "generic.numeric.integer_number()",
         sqltypes.Boolean: "generic.development.boolean()",
-        sqltypes.DateTime: "generic.datetime.datetime()",
         sqltypes.Date: "generic.datetime.date()",
-        sqltypes.Integer: "generic.numeric.integer_number()",
-        sqltypes.Text: "generic.text.color()",
+        sqltypes.DateTime: "generic.datetime.datetime()",
         sqltypes.Float: "generic.numeric.float_number()",
+        sqltypes.Integer: "generic.numeric.integer_number()",
         sqltypes.LargeBinary: "generic.binary_provider.bytes()",
+        sqltypes.Numeric: "generic.numeric.float_number()",
+        sqltypes.String: "generic.text.color()",
+        sqltypes.Text: "generic.text.color()",
     }
 
     for table in tables_module.Base.metadata.sorted_tables:

--- a/tests/examples/example_orm.py
+++ b/tests/examples/example_orm.py
@@ -35,3 +35,15 @@ class HopsitalVisit(Base):
     visit_end = Column(Date)
     visit_duration_seconds = Column(Float)
     visit_image = Column(LargeBinary)
+
+
+class Entity(Base):
+    __tablename__ = "entity"
+    __table_args__ = {"schema": "myschema"}
+
+    # NB Do not add any more columns to this table as
+    # we use it to test what happens in the one-column case
+    entity_id = Column(
+        Integer,
+        primary_key=True,
+    )

--- a/tests/examples/expected_ssg.py
+++ b/tests/examples/expected_ssg.py
@@ -8,8 +8,14 @@ generic.add_provider(ForeignKeyProvider)
 generic.add_provider(BinaryProvider)
 
 
+class entityGenerator:
+    def __init__(self, db_connection):
+        pass
+
+
 class personGenerator:
     def __init__(self, db_connection):
+        pass
         self.name = generic.text.color()
         self.nhs_number = generic.text.color()
         self.research_opt_out = generic.development.boolean()
@@ -19,6 +25,7 @@ class personGenerator:
 
 class hospital_visitGenerator:
     def __init__(self, db_connection):
+        pass
         self.person_id = generic.foreign_key_provider.key(db_connection, "myschema", "person", "person_id")
         self.visit_start = generic.datetime.datetime()
         self.visit_end = generic.datetime.date()
@@ -27,6 +34,7 @@ class hospital_visitGenerator:
 
 
 sorted_generators = [
+    entityGenerator,
     personGenerator,
     hospital_visitGenerator,
 ]


### PR DESCRIPTION
Previously, we did nothing (`continue`d) if we came across a primary key. This has the problem that tables with a single, PK, column end up with an empty `__init__()` method.