### PR TITLE
42 num rows per pass

### DIFF
--- a/sqlsynthgen/main.py
+++ b/sqlsynthgen/main.py
@@ -45,7 +45,7 @@ def read_yaml_file(path: str) -> Any:
 def create_data(
     orm_file: str = typer.Argument(...),
     ssg_file: str = typer.Argument(...),
-    num_rows: int = typer.Argument(...),
+    num_passes: int = typer.Argument(...),
 ) -> None:
     """Populate schema with synthetic data.
 
@@ -68,7 +68,7 @@ def create_data(
     Args:
         orm_file (str): Path to object relational model.
         ssg_file (str): Path to sqlsyngen output.
-        num_rows (int): Number of rows of values required
+        num_passes (int): Number of passes to make.
 
     Returns:
         None
@@ -76,7 +76,7 @@ def create_data(
     orm_module = import_file(orm_file)
     ssg_module = import_file(ssg_file)
     create_db_data(
-        orm_module.Base.metadata.sorted_tables, ssg_module.sorted_generators, num_rows
+        orm_module.Base.metadata.sorted_tables, ssg_module.sorted_generators, num_passes
     )
 
 

--- a/sqlsynthgen/main.py
+++ b/sqlsynthgen/main.py
@@ -63,7 +63,7 @@ def create_data(
     Final input is the number of rows required.
 
     Example:
-        $ python sqlsynthgen/main.py create-data example_orm.py expected_ssg.py 100
+        $ sqlsynthgen create-data example_orm.py expected_ssg.py 100
 
     Args:
         orm_file (str): Path to object relational model.
@@ -95,7 +95,7 @@ def create_tables(orm_file: str = typer.Argument(...)) -> None:
     declared as Python tables. (eg.)
 
     Example:
-        $ python sqlsynthgen/main.py create-tables example_orm.py
+        $ sqlsynthgen create-tables example_orm.py
 
     Args:
         orm_file (str): Path to Python tables file.
@@ -119,7 +119,7 @@ def make_generators(
     returns a set of synthetic data generators for each attribute
 
     Example:
-        $ python sqlsynthgen/main.py make-generators example_orm.py
+        $ sqlsynthgen make-generators example_orm.py
 
     Args:
         orm_file (str): Path to Python tables file.
@@ -140,7 +140,7 @@ def make_tables() -> None:
     as Python classes.
 
     Example:
-        $ python sqlsynthgen/main.py make_tables
+        $ sqlsynthgen make_tables
     """
     settings = get_settings()
 

--- a/tests/examples/expected_ssg.py
+++ b/tests/examples/expected_ssg.py
@@ -20,11 +20,15 @@ from . import custom_generators
 concept_vocab = FileUploader(tests.examples.example_orm.Concept.__table__)
 
 class entityGenerator:
+    num_rows_per_pass = 1
+
     def __init__(self, src_db_conn, dst_db_conn):
         pass
 
 
 class personGenerator:
+    num_rows_per_pass = 2
+
     def __init__(self, src_db_conn, dst_db_conn):
         self.name = generic.person.full_name()
         self.stored_from = generic.datetime.datetime(start=2022, end=2022)
@@ -35,6 +39,8 @@ class personGenerator:
 
 
 class hospital_visitGenerator:
+    num_rows_per_pass = 3
+
     def __init__(self, src_db_conn, dst_db_conn):
         self.visit_start, self.visit_end, self.visit_duration_seconds = custom_generators.timespan_generator(generic=generic, earliest_start_year=2021, last_start_year=2022, min_dt_days=1, max_dt_days=30)
         pass

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -48,16 +48,17 @@ class MyTestCase(TestCase):
             mock_src_conn = MagicMock()
             mock_dst_conn = MagicMock()
             mock_gen = MagicMock()
+            mock_gen.num_rows_per_pass = 2
             tables = [None]
             generators = [mock_gen]
             populate(mock_src_conn, mock_dst_conn, tables, generators, 1)
 
-            mock_gen.assert_called_once_with(mock_src_conn, mock_dst_conn)
-            mock_insert.return_value.values.assert_called_once_with(
-                mock_gen.return_value.__dict__
+            mock_gen.assert_has_calls([call(mock_src_conn, mock_dst_conn)] * 2)
+            mock_insert.return_value.values.assert_has_calls(
+                [call(mock_gen.return_value.__dict__)] * 2
             )
-            mock_dst_conn.execute.assert_called_once_with(
-                mock_insert.return_value.values.return_value
+            mock_dst_conn.execute.assert_has_calls(
+                [call(mock_insert.return_value.values.return_value)] * 2
             )
 
     def test_populate_diff_length(self) -> None:


### PR DESCRIPTION
Closes #42 

- Converts the `num_rows_per_pass: 2` entry in the config .yaml into a `num_rows_per_pass = 2` member variable in the generator class when we do `make-generators ...`.
- Runs the generator that many times when we do `create-data ...`.

