### PR TITLE
46 tables without pks

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,13 @@ Draft sqlsynthgen's documentation
 
    This project will be under active development from Jan - Oct 2023
 
+
+.. note::
+
+   We do not currently support tables without primary keys.
+   If you have tables without primary keys, some sqlsynthgen functionality
+   may work but vocabulary tables will not.
+
 Contents:
 ---------
 

--- a/sqlsynthgen/main.py
+++ b/sqlsynthgen/main.py
@@ -159,6 +159,14 @@ def make_tables() -> None:
         print(e.stderr, file=stderr)
         sys.exit(e.returncode)
 
+    # sqlacodegen falls back on Tables() for tables without PKs,
+    # but we don't explicitly support Tables and behaviour is unpredictable.
+    if " = Table(" in completed_process.stdout:
+        print(
+            "WARNING: Table without PK detected. sqlsynthgen may not be able to continue.",
+            file=stderr,
+        )
+
     print(completed_process.stdout)
 
 

--- a/tests/examples/src.dump
+++ b/tests/examples/src.dump
@@ -66,8 +66,8 @@ CREATE TABLE public.person (
     stored_from timestamp with time zone NOT NULL
 );
 
-
 ALTER TABLE public.person OWNER TO postgres;
+
 
 --
 -- Name: hospital_visit; Type: TABLE; Schema: public; Owner: postgres
@@ -83,6 +83,16 @@ CREATE TABLE public.hospital_visit (
 );
 
 ALTER TABLE public.hospital_visit OWNER TO postgres;
+
+--
+-- Name: hospital_visit; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.no_pk_test (
+    not_an_id integer NOT NULL
+);
+
+ALTER TABLE public.no_pk_test OWNER TO postgres;
 
 --
 -- Data for Name: hospital_visit; Type: TABLE DATA; Schema: public; Owner: postgres

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -117,6 +117,32 @@ class TestCLI(TestCase):
             [call.write("some-error-output"), call.write("\n")]
         )
 
+    def test_make_tables_warns_no_pk(self) -> None:
+        """Test the make-tables sub-command warns about Tables()."""
+        with patch("sqlsynthgen.main.run") as mock_run, patch(
+            "sqlsynthgen.main.get_settings"
+        ) as mock_get_settings, patch("sqlsynthgen.main.stderr") as mock_stderr:
+            mock_get_settings.return_value = get_test_settings()
+            mock_run.return_value.stdout = "t_nopk_table = Table("
+
+            result = runner.invoke(
+                app,
+                [
+                    "make-tables",
+                ],
+                catch_exceptions=False,
+            )
+
+        self.assertEqual(0, result.exit_code)
+        mock_stderr.assert_has_calls(
+            [
+                call.write(
+                    "WARNING: Table without PK detected. sqlsynthgen may not be able to continue."
+                ),
+                call.write("\n"),
+            ]
+        )
+
     def test_make_generators(self) -> None:
         """Test the make-generators sub-command."""
         with patch("sqlsynthgen.main.make_generators_from_tables") as mock_make:


### PR DESCRIPTION
1. Add a table without a PK to the test database via `src.dump` file
2. Add note to docs about tables without PKs

As far as I can tell, the basic functionality of SSG does work when a tables doesn't have a PK. However, vocabularies don't work (a relatively easy naming fix if we wanted).