### PR TITLE
Change directory more safely in unit tests

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,5 +1,6 @@
 """Tests for the base module."""
 import os
+from pathlib import Path
 
 from sqlalchemy import Column, Integer, create_engine, select
 from sqlalchemy.orm import declarative_base
@@ -26,6 +27,9 @@ class BaseTable(Base):  # type: ignore
 class VocabTests(RequiresDBTestCase):
     """Module test case."""
 
+    test_dir = Path("tests/examples")
+    start_dir = os.getcwd()
+
     def setUp(self) -> None:
         """Pre-test setup."""
 
@@ -35,10 +39,10 @@ class VocabTests(RequiresDBTestCase):
             "postgresql://postgres:password@localhost:5432/providers"
         )
         metadata.create_all(self.engine)
-        os.chdir("tests/examples")
+        os.chdir(self.test_dir)
 
     def tearDown(self) -> None:
-        os.chdir("../..")
+        os.chdir(self.start_dir)
 
     def test_load(self) -> None:
         """Test the load method."""

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -33,7 +33,7 @@ class VocabTests(RequiresDBTestCase):
     def setUp(self) -> None:
         """Pre-test setup."""
 
-        run_psql("providers.dump")
+        run_psql(Path("tests/examples/providers.dump"))
 
         self.engine = create_engine(
             "postgresql://postgres:password@localhost:5432/providers"

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -19,6 +19,9 @@ class FunctionalTestCase(RequiresDBTestCase):
 
     concept_file_path = Path("concept.csv")
 
+    test_dir = Path("tests/workspace")
+    start_dir = os.getcwd()
+
     env = os.environ.copy()
     env = {
         **env,
@@ -39,7 +42,7 @@ class FunctionalTestCase(RequiresDBTestCase):
         # Create a blank destination database
         run_psql("dst.dump")
 
-        os.chdir("tests/workspace")
+        os.chdir(self.test_dir)
 
         for file_path in (
             self.orm_file_path,
@@ -51,7 +54,7 @@ class FunctionalTestCase(RequiresDBTestCase):
             file_path.unlink(missing_ok=True)
 
     def tearDown(self) -> None:
-        os.chdir("../../")
+        os.chdir(self.start_dir)
 
     def test_workflow_minimal_args(self) -> None:
         """Test the recommended CLI workflow runs without errors."""

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -40,7 +40,7 @@ class FunctionalTestCase(RequiresDBTestCase):
         """Pre-test setup."""
 
         # Create a blank destination database
-        run_psql("dst.dump")
+        run_psql(Path("tests/examples/dst.dump"))
 
         os.chdir(self.test_dir)
 

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -1,6 +1,7 @@
 """Tests for the main module."""
 import os
 from io import StringIO
+from pathlib import Path
 from subprocess import CalledProcessError
 from unittest import TestCase
 from unittest.mock import MagicMock, call, patch
@@ -16,14 +17,16 @@ from tests.utils import SysExit
 class TestMake(TestCase):
     """Tests that don't require a database."""
 
+    test_dir = Path("tests/examples")
+    start_dir = os.getcwd()
+
     def setUp(self) -> None:
         """Pre-test setup."""
-
-        os.chdir("tests/examples")
+        os.chdir(self.test_dir)
 
     def tearDown(self) -> None:
         """Post-test cleanup."""
-        os.chdir("../..")
+        os.chdir(self.start_dir)
 
     @patch("sqlsynthgen.make.get_settings")
     @patch("sqlsynthgen.make.create_engine")

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,5 +1,6 @@
 """Tests for the providers module."""
 import datetime as dt
+from pathlib import Path
 from unittest import TestCase
 
 from sqlalchemy import Column, Integer, Text, create_engine, insert
@@ -40,7 +41,7 @@ class ColumnValueProviderTestCase(RequiresDBTestCase):
     def setUp(self) -> None:
         """Pre-test setup."""
 
-        run_psql("providers.dump")
+        run_psql(Path("tests/examples/providers.dump"))
 
         self.engine = create_engine(
             "postgresql://postgres:password@localhost:5432/providers",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,7 +62,7 @@ class TestDownload(RequiresDBTestCase):
     def setUp(self) -> None:
         """Pre-test setup."""
 
-        run_psql("providers.dump")
+        run_psql(Path("tests/examples/providers.dump"))
 
         self.engine = create_engine(
             "postgresql://postgres:password@localhost:5432/providers",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,13 +31,16 @@ class MyTable(Base):  # type: ignore
 class TestImport(TestCase):
     """Tests for the import_file function."""
 
+    test_dir = Path("tests/examples")
+    start_dir = os.getcwd()
+
     def setUp(self) -> None:
         """Pre-test setup."""
-
-        os.chdir("tests/examples")
+        os.chdir(self.test_dir)
 
     def tearDown(self) -> None:
-        os.chdir("../../")
+        """Post-test cleanup."""
+        os.chdir(self.start_dir)
 
     def test_import_file(self) -> None:
         """Test that we can import an example module."""
@@ -53,6 +56,9 @@ class TestDownload(RequiresDBTestCase):
 
     mytable_file_path = Path("mytable.csv")
 
+    test_dir = Path("tests/workspace")
+    start_dir = os.getcwd()
+
     def setUp(self) -> None:
         """Pre-test setup."""
 
@@ -64,12 +70,12 @@ class TestDownload(RequiresDBTestCase):
         )
         metadata.create_all(self.engine)
 
-        os.chdir("tests/workspace")
+        os.chdir(self.test_dir)
         self.mytable_file_path.unlink(missing_ok=True)
 
     def tearDown(self) -> None:
         """Post-test cleanup."""
-        os.chdir("../..")
+        os.chdir(self.start_dir)
 
     def test_download_table(self) -> None:
         """Test the download_table function."""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -30,7 +30,7 @@ def get_test_settings() -> settings.Settings:
     )
 
 
-def run_psql(dump_file_name: str) -> None:
+def run_psql(dump_file: Path) -> None:
     """Run psql and pass dump_file_name as the --file option."""
 
     # If you need to update a .dump file, use
@@ -41,12 +41,7 @@ def run_psql(dump_file_name: str) -> None:
 
     # Clear and re-create the test database
     completed_process = run(
-        [
-            "psql",
-            "--host=localhost",
-            "--username=postgres",
-            "--file=" + str(Path(f"tests/examples/{dump_file_name}")),
-        ],
+        ["psql", "--host=localhost", "--username=postgres", f"--file={dump_file}"],
         capture_output=True,
         env=env,
         check=True,
@@ -57,7 +52,7 @@ def run_psql(dump_file_name: str) -> None:
 
 @skipUnless(os.environ.get("REQUIRES_DB") == "1", "Set 'REQUIRES_DB=1' to enable.")
 class RequiresDBTestCase(TestCase):
-    """A test case that only runs if REQUIRES_DB has been set to true."""
+    """A test case that only runs if REQUIRES_DB has been set to 1."""
 
     def setUp(self) -> None:
         pass


### PR DESCRIPTION
A slight improvement over the previous system since we now save the starting directory in `setUp` and return to it in `tearDown`. Previously, we did `chdir('../..')` in `tearDown`, which could go wrong if something unexpected happened in `setUp` or if an extra `chdir()` was used in the test functions themselves.

Some improvements that could be added here or in a future PR

- Reduce duplication by moving the `examples/` and `workspace/` directories to the test utils module and making them `Final`.
- `run_psql()` presumes that it is being called from the repo root directory. This doesn't feel good as it then matters which order you do the `setUp` calls in. Is there a way we can remove this reliance on the current working directory to run the db setup scripts with psql?