### PR TITLE
Allow users to specify the destination schema name

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -9,7 +9,7 @@ extension-pkg-allow-list=
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code. (This is an alternative name to extension-pkg-allow-list
 # for backward compatibility.)
-extension-pkg-whitelist=
+extension-pkg-whitelist=pydantic
 
 # Return non-zero exit code if any of these messages/categories are detected,
 # even if score is above --fail-under value. Syntax same as enable. Messages

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -1,17 +1,7 @@
 FAQ
 ===
 
-How can you choose a different destination schema name
-******************************************************
+Can sqlsynthgen work with two different schemas
+***********************************************
 
-If you want the destination schema to have a different name to the source schema, you will need to open the SQLAlchemy ORM file you created with the `make-tables` command and replace all instances of
-
-.. code-block:: python
-
-    __table_args__ = {"schema": "source-schema-name"}
-
-with
-
-.. code-block:: python
-
-    __table_args__ = {"schema": "destination-schema-name"}
+sqlsynthgen can only work with a single source schema and a single destination schema at a time. However, you can choose for the destination schema to have a different name to the source schema by setting the DST_SCHEMA environment variable.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -1,0 +1,17 @@
+FAQ
+===
+
+How can you choose a different destination schema name
+******************************************************
+
+If you want the destination schema to have a different name to the source schema, you will need to open the SQLAlchemy ORM file you created with the `make-tables` command and replace all instances of
+
+.. code-block:: python
+
+    __table_args__ = {"schema": "source-schema-name"}
+
+with
+
+.. code-block:: python
+
+    __table_args__ = {"schema": "destination-schema-name"}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,6 +27,7 @@ Contents:
 
    installation
    sqlsynthgen
+   faq
    changelog
 
 

--- a/sqlsynthgen/create.py
+++ b/sqlsynthgen/create.py
@@ -39,7 +39,7 @@ def create_db_vocab(sorted_vocab: List[Any]) -> None:
 
     with dst_engine.connect() as dst_conn:
         if settings.dst_schema:
-            dst_conn.execute(f"SET SEARCH_PATH TO {settings.dst_schema}")
+            dst_conn.execute(f'SET SEARCH_PATH TO "{settings.dst_schema}"')
 
         for vocab_table in sorted_vocab:
             vocab_table.load(dst_conn)

--- a/sqlsynthgen/create.py
+++ b/sqlsynthgen/create.py
@@ -37,7 +37,7 @@ def create_db_vocab(sorted_vocab: List[Any]) -> None:
             settings.dst_postgres_dsn, settings.dst_schema  # type: ignore
         )
         if settings.dst_schema
-        else create_engine(settings.src_postgres_dsn)
+        else create_engine(settings.dst_postgres_dsn)
     )
 
     with dst_engine.connect() as dst_conn:
@@ -56,7 +56,7 @@ def create_db_data(
             settings.dst_postgres_dsn, settings.dst_schema  # type: ignore
         )
         if settings.dst_schema
-        else create_engine(settings.src_postgres_dsn)
+        else create_engine(settings.dst_postgres_dsn)
     )
     src_engine = (
         create_engine_with_search_path(

--- a/sqlsynthgen/create.py
+++ b/sqlsynthgen/create.py
@@ -1,25 +1,34 @@
 """Functions and classes to create and populate the target database."""
 from typing import Any, List
 
-from sqlalchemy import create_engine, insert
+from sqlalchemy import create_engine, event, insert
 from sqlalchemy.schema import CreateSchema
 
 from sqlsynthgen.settings import get_settings
+from sqlsynthgen.utils import set_search_path
 
 
 def create_db_tables(metadata: Any) -> Any:
     """Create tables described by the sqlalchemy metadata object."""
     settings = get_settings()
+
     engine = create_engine(settings.dst_postgres_dsn)
-    # Create schemas, if necessary.
-    for table in metadata.sorted_tables:
-        try:
-            schema = table.schema
-            if not engine.dialect.has_schema(engine, schema=schema):
-                engine.execute(CreateSchema(schema, if_not_exists=True))
-        except AttributeError:
-            # This table didn't have a schema field
-            pass
+
+    # Create schema, if necessary.
+    if settings.dst_schema:
+        schema_name = settings.dst_schema
+        if not engine.dialect.has_schema(engine, schema=schema_name):
+            engine.execute(CreateSchema(schema_name, if_not_exists=True))
+
+        # Recreate the engine and, this time, set a connection callback
+        engine = create_engine(settings.dst_postgres_dsn)
+
+        if schema_name:
+
+            @event.listens_for(engine, "connect", insert=True)
+            def connect(dbapi_connection: Any, _: Any) -> None:
+                set_search_path(dbapi_connection, schema_name)
+
     metadata.create_all(engine)
 
 
@@ -29,6 +38,9 @@ def create_db_vocab(sorted_vocab: List[Any]) -> None:
     dst_engine = create_engine(settings.dst_postgres_dsn)
 
     with dst_engine.connect() as dst_conn:
+        if settings.dst_schema:
+            dst_conn.execute(f"SET SEARCH_PATH TO {settings.dst_schema}")
+
         for vocab_table in sorted_vocab:
             vocab_table.load(dst_conn)
 
@@ -38,10 +50,18 @@ def create_db_data(
 ) -> None:
     """Connect to a database and populate it with data."""
     settings = get_settings()
-    dst_engine = create_engine(settings.dst_postgres_dsn)
+    engine = create_engine(settings.dst_postgres_dsn)
+
+    if settings.dst_schema:
+        schema_name = settings.dst_schema
+
+        @event.listens_for(engine, "connect", insert=True)
+        def connect(dbapi_connection: Any, _: Any) -> None:
+            set_search_path(dbapi_connection, schema_name)
+
     src_engine = create_engine(settings.src_postgres_dsn)
 
-    with dst_engine.connect() as dst_conn:
+    with engine.connect() as dst_conn:
         with src_engine.connect() as src_conn:
             populate(src_conn, dst_conn, sorted_tables, sorted_generators, num_passes)
 

--- a/sqlsynthgen/create.py
+++ b/sqlsynthgen/create.py
@@ -39,7 +39,7 @@ def create_db_vocab(sorted_vocab: List[Any]) -> None:
 
     with dst_engine.connect() as dst_conn:
         if settings.dst_schema:
-            dst_conn.execute(f'SET SEARCH_PATH TO "{settings.dst_schema}"')
+            set_search_path(dst_conn, settings.dst_schema)
 
         for vocab_table in sorted_vocab:
             vocab_table.load(dst_conn)

--- a/sqlsynthgen/main.py
+++ b/sqlsynthgen/main.py
@@ -173,7 +173,7 @@ def make_tables(
 
     settings = get_settings()
 
-    content = make_tables_file(str(settings.src_postgres_dsn), settings.src_schema)
+    content = make_tables_file(settings.src_postgres_dsn, settings.src_schema)  # type: ignore
     orm_file_path.write_text(content, encoding="utf-8")
 
 

--- a/sqlsynthgen/make.py
+++ b/sqlsynthgen/make.py
@@ -262,9 +262,7 @@ def make_src_stats(
         The dictionary of src-stats.
     """
     if schema_name:
-        engine = create_engine_with_search_path(
-            dsn, schema_name, echo=False, future=True
-        )
+        engine = create_engine_with_search_path(dsn, schema_name)
     else:
         engine = create_engine(dsn, echo=False, future=True)
 

--- a/sqlsynthgen/make.py
+++ b/sqlsynthgen/make.py
@@ -7,11 +7,7 @@ from typing import Any, Final, Optional
 
 import snsql
 from mimesis.providers.base import BaseProvider
-
-# pylint: disable=no-name-in-module
 from pydantic import PostgresDsn
-
-# pylint: enable=no-name-in-module
 from sqlalchemy import MetaData, create_engine
 from sqlalchemy.sql import sqltypes
 

--- a/sqlsynthgen/make.py
+++ b/sqlsynthgen/make.py
@@ -263,7 +263,9 @@ def make_src_stats(dsn: str, config: dict, schema_name: Optional[str] = None) ->
 
         @event.listens_for(engine, "connect", insert=True)
         def connect(dbapi_connection: Any, _: Any) -> None:
-            set_search_path(dbapi_connection, schema_name or "")
+            set_search_path(
+                dbapi_connection, schema_name or ""  # purely for type checking
+            )
 
     dp_config = config.get("smartnoise-sql", {})
     snsql_metadata = {"": dp_config}

--- a/sqlsynthgen/make.py
+++ b/sqlsynthgen/make.py
@@ -173,7 +173,7 @@ def make_generators_from_tables(
     settings = get_settings()
     engine = create_engine(settings.src_postgres_dsn)
 
-    for table in tables_module.metadata.sorted_tables:
+    for table in tables_module.Base.metadata.sorted_tables:
         table_config = generator_config.get("tables", {}).get(table.name, {})
 
         if table_config.get("vocabulary_table") is True:

--- a/sqlsynthgen/settings.py
+++ b/sqlsynthgen/settings.py
@@ -18,7 +18,6 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any, Optional
 
-# pylint: disable=no-name-in-module
 # pylint: disable=no-self-argument
 from pydantic import BaseSettings, PostgresDsn, validator
 

--- a/sqlsynthgen/settings.py
+++ b/sqlsynthgen/settings.py
@@ -76,6 +76,7 @@ class Settings(BaseSettings):
     dst_user_name: str  # e.g. "postgres" or "myuser@mydb"
     dst_password: str
     dst_db_name: str
+    dst_schema: Optional[str]
     dst_ssl_required: bool = False  # whether the db requires SSL
 
     # These are calculated so do not provide them explicitly

--- a/sqlsynthgen/utils.py
+++ b/sqlsynthgen/utils.py
@@ -9,11 +9,7 @@ from types import ModuleType
 from typing import Any
 
 import yaml
-
-# pylint: disable=no-name-in-module
 from pydantic import PostgresDsn
-
-# pylint: enable=no-name-in-module
 from sqlalchemy import create_engine, event, select
 
 

--- a/sqlsynthgen/utils.py
+++ b/sqlsynthgen/utils.py
@@ -54,7 +54,8 @@ def download_table(table: Any, engine: Any, schema: Optional[Any] = None) -> Non
     with engine.connect() as conn:
         if schema:
             conn.execute(f'SET SEARCH_PATH TO "{schema}"')
-        result = list(conn.execute(stmt))
+
+    result = list(conn.execute(stmt))
 
     with csv_file_path.open("w", newline="", encoding="utf-8") as csvfile:
         writer = csv.writer(csvfile, delimiter=",")

--- a/sqlsynthgen/utils.py
+++ b/sqlsynthgen/utils.py
@@ -62,11 +62,9 @@ def download_table(table: Any, engine: Any) -> None:
             writer.writerow(row)
 
 
-def create_engine_with_search_path(
-    postgres_dsn: PostgresDsn, schema_name: str, **create_engine_options: Any
-) -> Any:
+def create_engine_with_search_path(postgres_dsn: PostgresDsn, schema_name: str) -> Any:
     """Create a SQLAlchemy Engine with an explicitly set schema."""
-    engine = create_engine(postgres_dsn, **create_engine_options)
+    engine = create_engine(postgres_dsn)
 
     @event.listens_for(engine, "connect", insert=True)
     def connect(dbapi_connection: Any, _: Any) -> None:

--- a/sqlsynthgen/utils.py
+++ b/sqlsynthgen/utils.py
@@ -53,7 +53,7 @@ def download_table(table: Any, engine: Any, schema: Optional[Any] = None) -> Non
     stmt = select([table])
     with engine.connect() as conn:
         if schema:
-            conn.execute(f"SET SEARCH_PATH TO {schema}")
+            conn.execute(f'SET SEARCH_PATH TO "{schema}"')
         result = list(conn.execute(stmt))
 
     with csv_file_path.open("w", newline="", encoding="utf-8") as csvfile:
@@ -70,7 +70,7 @@ def set_search_path(connection: Any, schema: str) -> None:
     connection.autocommit = True
 
     cursor = connection.cursor()
-    cursor.execute(f"SET search_path to {schema};")
+    cursor.execute(f'SET search_path to "{schema}";')
     cursor.close()
 
     connection.autocommit = existing_autocommit

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -85,6 +85,7 @@ class MyTestCase(SSGTestCase):
         self, mock_get_settings: MagicMock, mock_create_engine: MagicMock
     ) -> None:
         """Test the create_db_vocab function."""
+        mock_get_settings.return_value = get_test_settings()
         vocab_list = [MagicMock()]
         create_db_vocab(vocab_list)
         vocab_list[0].load.assert_called_once_with(

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -36,13 +36,14 @@ class MyTestCase(SSGTestCase):
         self, mock_create_engine: MagicMock, mock_get_settings: MagicMock
     ) -> None:
         """Test the create_tables function."""
+        mock_get_settings.return_value.dst_schema = None
         mock_meta = MagicMock()
 
         create_db_tables(mock_meta)
-        mock_get_settings.assert_called_once()
         mock_create_engine.assert_called_once_with(
             mock_get_settings.return_value.dst_postgres_dsn
         )
+        mock_meta.create_all.assert_called_once_with(mock_create_engine.return_value)
 
     @patch("sqlsynthgen.create.insert")
     def test_populate(self, mock_insert: MagicMock) -> None:

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -31,7 +31,6 @@ class FunctionalTestCase(RequiresDBTestCase):
         "src_user_name": "postgres",
         "src_password": "password",
         "src_db_name": "src",
-        "src_schema": "",
         "dst_host_name": "localhost",
         "dst_user_name": "postgres",
         "dst_password": "password",

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import yaml
+from pydantic import PostgresDsn
 
 from sqlsynthgen.make import (
     make_generators_from_tables,
@@ -77,7 +78,7 @@ class TestMakeTables(SSGTestCase):
 
         self.assertEqual(
             "some generated code",
-            make_tables_file("postgresql://postgres@1.2.3.4/db", None),
+            make_tables_file(PostgresDsn("postgresql://postgres@1.2.3.4/db"), None),
         )
 
     @patch("sqlsynthgen.make.MetaData")
@@ -96,7 +97,9 @@ class TestMakeTables(SSGTestCase):
 
         self.assertEqual(
             "some generated code",
-            make_tables_file("postgresql://postgres@1.2.3.4/db", "myschema"),
+            make_tables_file(
+                PostgresDsn("postgresql://postgres@1.2.3.4/db"), "myschema"
+            ),
         )
 
     @patch("sqlsynthgen.make.MetaData")
@@ -115,7 +118,7 @@ class TestMakeTables(SSGTestCase):
             "t_nopk_table = Table("
         )
 
-        make_tables_file("postgresql://postgres@127.0.0.1:5432", None)
+        make_tables_file(PostgresDsn("postgresql://postgres@127.0.0.1:5432"), None)
 
         self.assertEqual(
             "WARNING: Table without PK detected. sqlsynthgen may not be able to continue.\n",

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -2,19 +2,21 @@
 import os
 from io import StringIO
 from pathlib import Path
-from subprocess import CalledProcessError
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import yaml
 
-from sqlsynthgen import make
-from sqlsynthgen.make import make_tables_file
+from sqlsynthgen.make import (
+    make_generators_from_tables,
+    make_src_stats,
+    make_tables_file,
+)
 from tests.examples import example_orm
-from tests.utils import SSGTestCase, SysExit
+from tests.utils import RequiresDBTestCase, SSGTestCase
 
 
-class TestMake(SSGTestCase):
-    """Tests that don't require a database."""
+class TestMakeGenerators(SSGTestCase):
+    """Test the make_generators_from_tables function."""
 
     test_dir = Path("tests/examples")
     start_dir = os.getcwd()
@@ -41,88 +43,99 @@ class TestMake(SSGTestCase):
             config = yaml.safe_load(f)
         stats_path = "example_stats.yaml"
 
-        actual = make.make_generators_from_tables(example_orm, config, stats_path)
+        actual = make_generators_from_tables(example_orm, config, stats_path)
         mock_download.assert_called_once()
         mock_create.assert_called_once()
 
         self.assertEqual(expected, actual)
 
-    @patch("sqlsynthgen.make.run")
-    def test_make_tables_file(self, mock_run: MagicMock) -> None:
+
+class TestMakeTables(SSGTestCase):
+    """Test the make_tables function."""
+
+    test_dir = Path("tests/examples")
+    start_dir = os.getcwd()
+
+    def setUp(self) -> None:
+        """Pre-test setup."""
+        os.chdir(self.test_dir)
+
+    def tearDown(self) -> None:
+        """Post-test cleanup."""
+        os.chdir(self.start_dir)
+
+    @patch("sqlsynthgen.make.MetaData")
+    @patch("sqlsynthgen.make.entry_points")
+    def test_make_tables_file(self, mock_entry: MagicMock, _: MagicMock) -> None:
         """Test the make_tables_file function."""
-
-        mock_run.return_value.stdout = "some output"
-
-        make_tables_file("my:postgres/db", None)
+        mock_ep = MagicMock()
+        mock_ep.name = "declarative"
+        mock_ep.load.return_value.return_value.generate.return_value = (
+            "some generated code"
+        )
+        mock_entry.return_value = [mock_ep]
 
         self.assertEqual(
-            call(
-                [
-                    "sqlacodegen",
-                    "my:postgres/db",
-                ],
-                capture_output=True,
-                encoding="utf-8",
-                check=True,
-            ),
-            mock_run.call_args_list[0],
+            "some generated code",
+            make_tables_file("postgresql://postgres@1.2.3.4/db", None),
         )
 
-    @patch("sqlsynthgen.make.run")
-    def test_make_tables_file_with_schema(self, mock_run: MagicMock) -> None:
+    @patch("sqlsynthgen.make.MetaData")
+    @patch("sqlsynthgen.make.entry_points")
+    def test_make_tables_file_with_schema(
+        self, mock_entry: MagicMock, _: MagicMock
+    ) -> None:
         """Check that the function handles the schema setting."""
 
-        make_tables_file("my:postgres/db", "my_schema")
+        mock_ep = MagicMock()
+        mock_ep.name = "declarative"
+        mock_ep.load.return_value.return_value.generate.return_value = (
+            "some generated code"
+        )
+        mock_entry.return_value = [mock_ep]
 
         self.assertEqual(
-            call(
-                [
-                    "sqlacodegen",
-                    "--schema=my_schema",
-                    "my:postgres/db",
-                ],
-                capture_output=True,
-                encoding="utf-8",
-                check=True,
-            ),
-            mock_run.call_args_list[0],
+            "some generated code",
+            make_tables_file("postgresql://postgres@1.2.3.4/db", "myschema"),
         )
 
-    @patch("sys.exit")
+    @patch("sqlsynthgen.make.MetaData")
     @patch("sqlsynthgen.make.stderr", new_callable=StringIO)
-    @patch("sqlsynthgen.make.run")
-    def test_make_tables_handles_errors(
-        self, mock_run: MagicMock, mock_stderr: MagicMock, mock_exit: MagicMock
-    ) -> None:
-        """Test the make-tables sub-command handles sqlacodegen errors."""
-
-        mock_run.side_effect = CalledProcessError(
-            returncode=99, cmd="some-cmd", stderr="some-error-output"
-        )
-        mock_exit.side_effect = SysExit
-
-        try:
-            make_tables_file("my:postgres/db", None)
-        except SysExit:
-            pass
-
-        mock_exit.assert_called_once_with(99)
-        self.assertEqual("some-error-output\n", mock_stderr.getvalue())
-
-    @patch("sqlsynthgen.make.stderr", new_callable=StringIO)
-    @patch("sqlsynthgen.make.run")
+    @patch("sqlsynthgen.make.entry_points")
     def test_make_tables_warns_no_pk(
-        self, mock_run: MagicMock, mock_stderr: MagicMock
+        self, mock_entry: MagicMock, mock_stderr: MagicMock, _: MagicMock
     ) -> None:
         """Test the make-tables sub-command warns about Tables()."""
 
-        mock_run.return_value.stdout = "t_nopk_table = Table("
-        make_tables_file("my:postgres/db", None)
+        mock_ep = MagicMock()
+        mock_ep.name = "declarative"
+        mock_entry.return_value = [mock_ep]
+
+        mock_ep.load.return_value.return_value.generate.return_value = (
+            "t_nopk_table = Table("
+        )
+
+        make_tables_file("postgresql://postgres@127.0.0.1:5432", None)
 
         self.assertEqual(
             "WARNING: Table without PK detected. sqlsynthgen may not be able to continue.\n",
             mock_stderr.getvalue(),
         )
+
+
+class TestMakeStats(RequiresDBTestCase):
+    """Test the make_src_stats function."""
+
+    test_dir = Path("tests/examples")
+    start_dir = os.getcwd()
+
+    def setUp(self) -> None:
+        """Pre-test setup."""
+        os.chdir(self.test_dir)
+
+    def tearDown(self) -> None:
+        """Post-test cleanup."""
+        os.chdir(self.start_dir)
 
     def test_make_stats(self) -> None:
         """Test the make_src_stats function."""
@@ -130,11 +143,19 @@ class TestMake(SSGTestCase):
         conf_path = Path("example_config.yaml")
         with open(conf_path, "r", encoding="utf8") as f:
             config = yaml.safe_load(f)
-        src_stats = make.make_src_stats(connection_string, config)
-        self.assertSetEqual({"count_opt_outs"}, set(src_stats.keys()))
-        count_opt_outs = src_stats["count_opt_outs"]
-        self.assertEqual(len(count_opt_outs), 2)
-        self.assertIsInstance(count_opt_outs[0][0], int)
-        self.assertIs(count_opt_outs[0][1], False)
-        self.assertIsInstance(count_opt_outs[1][0], int)
-        self.assertIs(count_opt_outs[1][1], True)
+
+        # Check that make_src_stats works with, or without, a schema
+        for args in (
+            (connection_string, config),
+            (connection_string, config, "public"),
+        ):
+
+            src_stats = make_src_stats(*args)
+
+            self.assertSetEqual({"count_opt_outs"}, set(src_stats.keys()))
+            count_opt_outs = src_stats["count_opt_outs"]
+            self.assertEqual(len(count_opt_outs), 2)
+            self.assertIsInstance(count_opt_outs[0][0], int)
+            self.assertIs(count_opt_outs[0][1], False)
+            self.assertIsInstance(count_opt_outs[1][0], int)
+            self.assertIs(count_opt_outs[1][1], True)

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -71,15 +71,10 @@ class TestMakeTables(SSGTestCase):
         os.chdir(self.start_dir)
 
     @patch("sqlsynthgen.make.MetaData")
-    @patch("sqlsynthgen.make.entry_points")
-    def test_make_tables_file(self, mock_entry: MagicMock, _: MagicMock) -> None:
+    @patch("sqlsynthgen.make.DeclarativeGenerator")
+    def test_make_tables_file(self, mock_declarative: MagicMock, _: MagicMock) -> None:
         """Test the make_tables_file function."""
-        mock_ep = MagicMock()
-        mock_ep.name = "declarative"
-        mock_ep.load.return_value.return_value.generate.return_value = (
-            "some generated code"
-        )
-        mock_entry.return_value = [mock_ep]
+        mock_declarative.return_value.generate.return_value = "some generated code"
 
         self.assertEqual(
             "some generated code",
@@ -89,18 +84,12 @@ class TestMakeTables(SSGTestCase):
         )
 
     @patch("sqlsynthgen.make.MetaData")
-    @patch("sqlsynthgen.make.entry_points")
+    @patch("sqlsynthgen.make.DeclarativeGenerator")
     def test_make_tables_file_with_schema(
-        self, mock_entry: MagicMock, _: MagicMock
+        self, mock_declarative: MagicMock, _: MagicMock
     ) -> None:
         """Check that the function handles the schema setting."""
-
-        mock_ep = MagicMock()
-        mock_ep.name = "declarative"
-        mock_ep.load.return_value.return_value.generate.return_value = (
-            "some generated code"
-        )
-        mock_entry.return_value = [mock_ep]
+        mock_declarative.return_value.generate.return_value = "some generated code"
 
         self.assertEqual(
             "some generated code",
@@ -112,19 +101,12 @@ class TestMakeTables(SSGTestCase):
 
     @patch("sqlsynthgen.make.MetaData")
     @patch("sqlsynthgen.make.stderr", new_callable=StringIO)
-    @patch("sqlsynthgen.make.entry_points")
+    @patch("sqlsynthgen.make.DeclarativeGenerator")
     def test_make_tables_warns_no_pk(
-        self, mock_entry: MagicMock, mock_stderr: MagicMock, _: MagicMock
+        self, mock_declarative: MagicMock, mock_stderr: MagicMock, _: MagicMock
     ) -> None:
         """Test the make-tables sub-command warns about Tables()."""
-
-        mock_ep = MagicMock()
-        mock_ep.name = "declarative"
-        mock_entry.return_value = [mock_ep]
-
-        mock_ep.load.return_value.return_value.generate.return_value = (
-            "t_nopk_table = Table("
-        )
+        mock_declarative.return_value.generate.return_value = "t_nopk_table = Table("
 
         make_tables_file(
             parse_obj_as(PostgresDsn, "postgresql://postgres@127.0.0.1:5432"), None

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -26,6 +26,7 @@ class TestSettings(SSGTestCase):
             str(settings.src_postgres_dsn),
         )
         self.assertIsNone(settings.src_schema)
+        self.assertIsNone(settings.dst_schema)
 
         self.assertEqual(
             "postgresql://duser:dpassword@dhost:5432/ddbname",
@@ -46,6 +47,7 @@ class TestSettings(SSGTestCase):
             dst_user_name="duser",
             dst_password="dpassword",
             dst_db_name="ddbname",
+            dst_schema="dschema",
             dst_ssl_required=True,
             # To stop any local .env files influencing the test
             _env_file=None,


### PR DESCRIPTION
We manually set the schema name in for the whole connection session using an explicit `SET SEARCH_PATH TO` statement.

This allows the user to have a different destination schema name than the source schema.

The disadvantage is that we cannot support multiple source schemas (not that we did previously, but this makes it harder), though postgres does allow you to set more than one schema on a search path with `SET SEARCH_PATH TO schema1, schema2;`.

Would appreciate some testing on a real database.