### PR TITLE
Move form sorted_generators to generator_dict

### DIFF
--- a/sqlsynthgen/main.py
+++ b/sqlsynthgen/main.py
@@ -57,7 +57,7 @@ def create_data(
     orm_module = import_file(orm_file)
     ssg_module = import_file(ssg_file)
     create_db_data(
-        orm_module.Base.metadata.sorted_tables, ssg_module.sorted_generators, num_passes
+        orm_module.Base.metadata.sorted_tables, ssg_module.generator_dict, num_passes
     )
 
 
@@ -73,7 +73,7 @@ def create_vocab(ssg_file: str = typer.Option(SSG_FILENAME)) -> None:
           Must be in the current working directory.
     """
     ssg_module = import_file(ssg_file)
-    create_db_vocab(ssg_module.sorted_vocab)
+    create_db_vocab(ssg_module.vocab_dict)
 
 
 @app.command()

--- a/sqlsynthgen/make.py
+++ b/sqlsynthgen/make.py
@@ -163,8 +163,8 @@ def make_generators_from_tables(
             f"\n{INDENTATION}SRC_STATS = yaml.load(f, Loader=yaml.FullLoader)"
         )
 
-    sorted_generators = "[\n"
-    sorted_vocab = "[\n"
+    generator_dict = "{\n"
+    vocab_dict = "{\n"
 
     settings = get_settings()
     engine = (
@@ -188,7 +188,7 @@ def make_generators_from_tables(
                 f"\n\n{class_name.lower()}_vocab "
                 f"= FileUploader({tables_module.__name__}.{class_name}.__table__)"
             )
-            sorted_vocab += f"{INDENTATION}{class_name.lower()}_vocab,\n"
+            vocab_dict += f'{INDENTATION}"{table.name}": {class_name.lower()}_vocab,\n'
 
             download_table(table, engine)
 
@@ -196,13 +196,13 @@ def make_generators_from_tables(
             new_content, new_generator_name = _add_generator_for_table(
                 new_content, tables_module, table_config, table
             )
-            sorted_generators += f"{INDENTATION}{new_generator_name},\n"
+            generator_dict += f'{INDENTATION}"{table.name}": {new_generator_name},\n'
 
-    sorted_generators += "]"
-    sorted_vocab += "]"
+    generator_dict += "}"
+    vocab_dict += "}"
 
-    new_content += "\n\n" + "sorted_generators = " + sorted_generators + "\n"
-    new_content += "\n\n" + "sorted_vocab = " + sorted_vocab + "\n"
+    new_content += "\n\n" + "generator_dict = " + generator_dict + "\n"
+    new_content += "\n\n" + "vocab_dict = " + vocab_dict + "\n"
 
     return new_content
 

--- a/tests/examples/expected_ssg.py
+++ b/tests/examples/expected_ssg.py
@@ -53,13 +53,13 @@ class hospital_visitGenerator:
         self.visit_image = generic.bytes_provider.bytes()
 
 
-sorted_generators = [
-    entityGenerator,
-    personGenerator,
-    hospital_visitGenerator,
-]
+generator_dict = {
+    "entity": entityGenerator,
+    "person": personGenerator,
+    "hospital_visit": hospital_visitGenerator,
+}
 
 
-sorted_vocab = [
-    concept_vocab,
-]
+vocab_dict = {
+    "concept": concept_vocab,
+}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,7 +27,7 @@ class TestCLI(SSGTestCase):
             catch_exceptions=False,
         )
 
-        mock_create.assert_called_once_with(mock_import.return_value.sorted_vocab)
+        mock_create.assert_called_once_with(mock_import.return_value.vocab_dict)
         self.assertSuccess(result)
 
     @patch("sqlsynthgen.main.import_file")
@@ -115,7 +115,7 @@ class TestCLI(SSGTestCase):
 
         mock_create.assert_called_once_with(
             mock_import.return_value.Base.metadata.sorted_tables,
-            mock_import.return_value.sorted_generators,
+            mock_import.return_value.generator_dict,
             1,
         )
         self.assertSuccess(result)


### PR DESCRIPTION
The zipping of `sorted_tables` and `sorted_generators` started to fail when there were non-trivial foreign-key relations between vocabulary tables, which made them no longer all be at the beginning of `sorted_tables`. This PR switches to using a dictionary that maps table names to generators.