### PR TITLE
Allow reloading the same vocabulary without crashing

### DIFF
--- a/sqlsynthgen/create.py
+++ b/sqlsynthgen/create.py
@@ -1,7 +1,9 @@
 """Functions and classes to create and populate the target database."""
+import logging
 from typing import Any, Dict
 
 from sqlalchemy import create_engine, insert
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.schema import CreateSchema
 
 from sqlsynthgen.settings import get_settings
@@ -42,7 +44,11 @@ def create_db_vocab(vocab_dict: Dict[str, Any]) -> None:
 
     with dst_engine.connect() as dst_conn:
         for vocab_table in vocab_dict.values():
-            vocab_table.load(dst_conn)
+            try:
+                vocab_table.load(dst_conn)
+            except IntegrityError as e:
+                logging.warning("Loading the vocabulary table %s failed:", vocab_table)
+                logging.warning(e)
 
 
 def create_db_data(sorted_tables: list, generator_dict: dict, num_passes: int) -> None:

--- a/sqlsynthgen/main.py
+++ b/sqlsynthgen/main.py
@@ -114,6 +114,7 @@ def make_generators(
           Must be in the current working directory.
         ssg_file (str): Path to write the generators file to.
         config_file (str): Path to configuration file.
+        stats_file (str): Path to source stats file (output of make-stats).
     """
     ssg_file_path = Path(ssg_file)
     if ssg_file_path.exists():

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -104,3 +104,5 @@ class MyTestCase(SSGTestCase):
         mock_create_engine.assert_called_once_with(
             mock_get_settings.return_value.dst_postgres_dsn
         )
+        # Running the same insert twice should be fine.
+        create_db_vocab(vocab_list)


### PR DESCRIPTION
Running `create-vocab` twice used to crash with because of the uniqueness constraint violation when inserting the same data again. This one makes it rather print out the error as a warning, but soldiering on with the other tables.

This builds on #68, and the diff is going to be nicer if that one is merged first.