### PR TITLE
Add quickstart docs with simplest workflow

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,6 +26,7 @@ Contents:
    :maxdepth: 2
 
    installation
+   quickstart
    sqlsynthgen
    faq
    changelog

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,6 +1,8 @@
 Installation
 ============
 
+.. _enduser:
+
 End User
 --------
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -1,0 +1,59 @@
+Quick Start
+===========
+
+
+After :ref:`Installation <enduser>`, we need to set an environment variables to tell sqlsynthgen how to access our source database (where the real data resides now) and destination database (where the synthetic data will go).
+We can do that in the terminal with the `export` keyword, as shown below, or in a file called `.env`.
+The source and destination may be on the same database server, as long as the database or schema names differ.
+
+.. code-block:: console
+
+   $ export SRC_HOST_NAME='myserver@mydomain.com'
+   $ export SRC_USER_NAME='someuser'
+   $ export SRC_PASSWORD='secretpassword'
+   $ export SRC_SCHEMA='myschema'
+   $ export SRC_DB_NAME='source_db'
+
+   $ export DST_HOST_NAME='myserver@mydomain.com'
+   $ export DST_USER_NAME='someuser'
+   $ export DST_PASSWORD='secretpassword'
+   $ export DST_SCHEMA='myschema'
+   $ export DST_DB_NAME='destination_db'
+
+
+Next, we make a SQLAlchemy file that defines the structure of your database using the `make-tables` command:
+
+.. code-block:: console
+
+   $ sqlsynthgen make-tables
+
+This will have created a file called `orm.py` in the current directory, with a SQLAlchemy class for each of your tables.
+
+The next step is to make a sqlsynthgen file that defines one data generator per table in the source database:
+
+.. code-block:: console
+
+   $ sqlsynthgen make-generators
+
+This will have created a file called `ssg.py` in the current directory.
+
+We can use the `create-table` command to read the `orm.py` file, create our destination schema (if it doesn't already exist) and to create empty copies of all the tables that in the source database.
+
+.. code-block:: console
+
+   $ sqlsynthgen create-tables
+
+Now that we have created the schema that will hold synthetic data, we can use the `create-data` command to read `orm.py` & `ssg.py` and generate data:
+
+.. code-block:: console
+
+   $ sqlsynthgen create-data
+
+By default, `create-data` will have inserted one row per table and will have used the column data types to decide how to randomly generate data.
+To create more data each time we call `create-data`, we can provide an integer argument
+
+.. code-block:: console
+
+   $ sqlsynthgen create-data 10
+
+We will have inserted 11 rows per table, with the last two commands.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -1,8 +1,26 @@
 Quick Start
 ===========
 
+After :ref:`Installation <enduser>`, we can run sqlsynthgen with the `--help` option to see the available commands:
 
-After :ref:`Installation <enduser>`, we need to set an environment variables to tell sqlsynthgen how to access our source database (where the real data resides now) and destination database (where the synthetic data will go).
+.. code-block:: console
+
+   $ sqlsynthgen --help
+   Usage: sqlsynthgen [OPTIONS] COMMAND [ARGS]...
+
+   Options:
+     --help           Show this message and exit.
+
+   Commands:
+     create-data      Populate schema with synthetic data.
+     create-tables    Create schema from Python classes.
+     create-vocab     Create tables using the SQLAlchemy file.
+     make-generators  Make a SQLSynthGen file of generator classes.
+     make-stats       Compute summary statistics from the source database,...
+     make-tables      Make a SQLAlchemy file of Table classes.
+
+For the simplest case, we will need `make-tables`, `make-generators`, `create-tables` and `create-data` but, first,
+we need to set environment variables to tell sqlsynthgen how to access our source database (where the real data resides now) and destination database (where the synthetic data will go).
 We can do that in the terminal with the `export` keyword, as shown below, or in a file called `.env`.
 The source and destination may be on the same database server, as long as the database or schema names differ.
 
@@ -50,7 +68,7 @@ Now that we have created the schema that will hold synthetic data, we can use th
    $ sqlsynthgen create-data
 
 By default, `create-data` will have inserted one row per table and will have used the column data types to decide how to randomly generate data.
-To create more data each time we call `create-data`, we can provide an integer argument
+To create more data each time we call `create-data`, we can provide an integer argument:
 
 .. code-block:: console
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -3,7 +3,7 @@ name = "alabaster"
 version = "0.7.13"
 description = "A configurable sidebar-enabled Sphinx theme"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 
 [[package]]
@@ -32,7 +32,7 @@ name = "babel"
 version = "2.12.1"
 description = "Internationalization utilities"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 
 [[package]]
@@ -62,7 +62,7 @@ name = "certifi"
 version = "2022.12.7"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 
 [[package]]
@@ -70,7 +70,7 @@ name = "charset-normalizer"
 version = "3.1.0"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7.0"
 
 [[package]]
@@ -141,7 +141,7 @@ name = "idna"
 version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 
 [[package]]
@@ -149,7 +149,7 @@ name = "imagesize"
 version = "1.4.1"
 description = "Getting image size from png/jpeg/jpeg2000/gif file"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
@@ -202,7 +202,7 @@ name = "jinja2"
 version = "3.1.2"
 description = "A very fast and expressive template engine."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -224,7 +224,7 @@ name = "markupsafe"
 version = "2.1.2"
 description = "Safely add untrusted strings to HTML/XML markup."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 
 [[package]]
@@ -291,7 +291,7 @@ name = "packaging"
 version = "23.0"
 description = "Core utilities for Python packages"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 
 [[package]]
@@ -472,7 +472,7 @@ name = "requests"
 version = "2.28.2"
 description = "Python HTTP for Humans."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7, <4"
 
 [package.dependencies]
@@ -495,6 +495,26 @@ python-versions = "*"
 
 [package.dependencies]
 docutils = ">=0.11,<1.0"
+
+[[package]]
+name = "rstcheck-core"
+version = "1.0.3"
+description = "Checks syntax of reStructuredText and code blocks nested within it"
+category = "dev"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[package.dependencies]
+docutils = ">=0.7,<0.20"
+pydantic = ">=1.2,<2.0"
+sphinx = {version = ">=4.0,<6.0", optional = true, markers = "extra == \"sphinx\" or extra == \"docs\""}
+types-docutils = ">=0.18,<0.20"
+
+[package.extras]
+docs = ["m2r2 (>=0.3.2)", "sphinx (>=4.0,<6.0)", "sphinx-autobuild (==2021.3.14)", "sphinx-autodoc-typehints (>=1.15)", "sphinx-rtd-dark-mode (>=1.2.4,<2.0.0)", "sphinx-rtd-theme (<1)", "sphinxcontrib-apidoc (>=0.3)", "sphinxcontrib-spelling (>=7.3)"]
+sphinx = ["sphinx (>=4.0,<6.0)"]
+testing = ["coverage-conditional-plugin (>=0.5)", "coverage[toml] (>=6.0)", "pytest (>=6.0)", "pytest-cov (>=3.0)", "pytest-mock (>=3.7)", "pytest-randomly (>=3.0)", "pytest-sugar (>=0.9.5)"]
+toml = ["tomli (>=2.0,<3.0)"]
 
 [[package]]
 name = "six"
@@ -530,23 +550,23 @@ python-versions = "*"
 
 [[package]]
 name = "sphinx"
-version = "6.1.3"
+version = "5.3.0"
 description = "Python documentation generator"
 category = "main"
-optional = true
-python-versions = ">=3.8"
+optional = false
+python-versions = ">=3.6"
 
 [package.dependencies]
 alabaster = ">=0.7,<0.8"
 babel = ">=2.9"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
-docutils = ">=0.18,<0.20"
+docutils = ">=0.14,<0.20"
 imagesize = ">=1.3"
 importlib-metadata = {version = ">=4.8", markers = "python_version < \"3.10\""}
 Jinja2 = ">=3.0"
 packaging = ">=21.0"
-Pygments = ">=2.13"
-requests = ">=2.25.0"
+Pygments = ">=2.12"
+requests = ">=2.5.0"
 snowballstemmer = ">=2.0"
 sphinxcontrib-applehelp = "*"
 sphinxcontrib-devhelp = "*"
@@ -557,8 +577,8 @@ sphinxcontrib-serializinghtml = ">=1.1.5"
 
 [package.extras]
 docs = ["sphinxcontrib-websupport"]
-lint = ["docutils-stubs", "flake8 (>=3.5.0)", "flake8-simplify", "isort", "mypy (>=0.990)", "ruff", "sphinx-lint", "types-requests"]
-test = ["cython", "html5lib", "pytest (>=4.6)"]
+lint = ["docutils-stubs", "flake8 (>=3.5.0)", "flake8-bugbear", "flake8-comprehensions", "flake8-simplify", "isort", "mypy (>=0.981)", "sphinx-lint", "types-requests", "types-typed-ast"]
+test = ["cython", "html5lib", "pytest (>=4.6)", "typed_ast"]
 
 [[package]]
 name = "sphinx-rtd-theme"
@@ -581,7 +601,7 @@ name = "sphinxcontrib-applehelp"
 version = "1.0.4"
 description = "sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.8"
 
 [package.extras]
@@ -593,7 +613,7 @@ name = "sphinxcontrib-devhelp"
 version = "1.0.2"
 description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 
 [package.extras]
@@ -605,7 +625,7 @@ name = "sphinxcontrib-htmlhelp"
 version = "2.0.1"
 description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.8"
 
 [package.extras]
@@ -628,7 +648,7 @@ name = "sphinxcontrib-jsmath"
 version = "1.0.1"
 description = "A sphinx extension which renders display math in HTML via JavaScript"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 
 [package.extras]
@@ -651,7 +671,7 @@ name = "sphinxcontrib-qthelp"
 version = "1.0.3"
 description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 
 [package.extras]
@@ -663,7 +683,7 @@ name = "sphinxcontrib-serializinghtml"
 version = "1.1.5"
 description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 
 [package.extras]
@@ -785,6 +805,14 @@ doc = ["cairosvg (>=2.5.2,<3.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1
 test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.910)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "rich (>=10.11.0,<13.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
 
 [[package]]
+name = "types-docutils"
+version = "0.19.1.7"
+description = "Typing stubs for docutils"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "types-pyyaml"
 version = "6.0.12.8"
 description = "Typing stubs for PyYAML"
@@ -805,7 +833,7 @@ name = "urllib3"
 version = "1.26.15"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.extras]
@@ -839,7 +867,7 @@ docs = ["sphinx-rtd-theme", "sphinxcontrib-napoleon"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9,<3.11"
-content-hash = "45e19dfa0f1935a1bd3f3a5f6119adaa78eecdfb8c8e738bb3c1c4d36d59de7d"
+content-hash = "4fde3005a12456c94dc80c7b4e9f2c2ccfc06bbdab07e2b9403baa5afa61c0c7"
 
 [metadata.files]
 alabaster = [
@@ -1446,6 +1474,10 @@ requests = [
 restructuredtext-lint = [
     {file = "restructuredtext_lint-1.4.0.tar.gz", hash = "sha256:1b235c0c922341ab6c530390892eb9e92f90b9b75046063e047cacfb0f050c45"},
 ]
+rstcheck-core = [
+    {file = "rstcheck_core-1.0.3-py3-none-any.whl", hash = "sha256:d75d7df8f15b58e8aafe322d6fb6ef1ac8d12bb563089b0696948a00ee7f601a"},
+    {file = "rstcheck_core-1.0.3.tar.gz", hash = "sha256:add19c9a1b97d9087f4b463b49c12cd8a9c03689a255e99089c70a2692f16369"},
+]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
@@ -1459,8 +1491,8 @@ snowballstemmer = [
     {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
 ]
 sphinx = [
-    {file = "Sphinx-6.1.3.tar.gz", hash = "sha256:0dac3b698538ffef41716cf97ba26c1c7788dba73ce6f150c1ff5b4720786dd2"},
-    {file = "sphinx-6.1.3-py3-none-any.whl", hash = "sha256:807d1cb3d6be87eb78a381c3e70ebd8d346b9a25f3753e9947e866b2786865fc"},
+    {file = "Sphinx-5.3.0.tar.gz", hash = "sha256:51026de0a9ff9fc13c05d74913ad66047e104f56a129ff73e174eb5c3ee794b5"},
+    {file = "sphinx-5.3.0-py3-none-any.whl", hash = "sha256:060ca5c9f7ba57a08a1219e547b269fadf125ae25b06b9fa7f66768efb652d6d"},
 ]
 sphinx-rtd-theme = [
     {file = "sphinx_rtd_theme-1.2.0-py2.py3-none-any.whl", hash = "sha256:f823f7e71890abe0ac6aaa6013361ea2696fc8d3e1fa798f463e82bdb77eeff2"},
@@ -1557,6 +1589,10 @@ tomlkit = [
 typer = [
     {file = "typer-0.7.0-py3-none-any.whl", hash = "sha256:b5e704f4e48ec263de1c0b3a2387cd405a13767d2f907f44c1a08cbad96f606d"},
     {file = "typer-0.7.0.tar.gz", hash = "sha256:ff797846578a9f2a201b53442aedeb543319466870fbe1c701eab66dd7681165"},
+]
+types-docutils = [
+    {file = "types-docutils-0.19.1.7.tar.gz", hash = "sha256:cb6e0dd1c895c723002ec4dc8334bf9df04726ef0cf13f5597501578b47eef30"},
+    {file = "types_docutils-0.19.1.7-py3-none-any.whl", hash = "sha256:bbf89cf3b9460ce780434f8cc52ce846b0f14505ff3496fc6a17acd9967aee9e"},
 ]
 types-pyyaml = [
     {file = "types-PyYAML-6.0.12.8.tar.gz", hash = "sha256:19304869a89d49af00be681e7b267414df213f4eb89634c4495fa62e8f942b9f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ types-pyyaml = "^6.0.12.4"
 pydocstyle = "^6.3.0"
 restructuredtext-lint = "^1.4.0"
 pygments = "^2.14.0"
+rstcheck-core = {extras = ["sphinx"], version = "^1.0.3"}
 
 [tool.poetry.extras]
 docs = ["sphinx-rtd-theme", "sphinxcontrib-napoleon"]

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -24,6 +24,7 @@ class RstTests(TestCase):
             'No role entry for "ref" in module',
             'No directive entry for "toctree"',
             'No directive entry for "automodule"',
+            'Hyperlink target "enduser" is not referenced',
         ]
         filtered_errors = []
         for file_errors in all_errors:


### PR DESCRIPTION
This PR aims to document the simplest possible workflow:

- make tables, make generators, create tables & create data
- No vocab
- No stats
- No config file

Even though it is good to keep a quickstart simple, I do think that we should add at least two more examples, to show the use of the stats and vocab functions. I think it should be fine to do that in separate PRs, though.