### PR TITLE
ColumnValueProvider returns None when extracting values from empty tables

### DIFF
--- a/sqlsynthgen/base.py
+++ b/sqlsynthgen/base.py
@@ -19,5 +19,6 @@ class FileUploader:
             "r", newline="", encoding="utf-8"
         ) as yamlfile:
             rows = yaml.load(yamlfile, Loader=yaml.Loader)
-            stmt = insert(self.table).values(list(rows))
-        connection.execute(stmt)
+            if rows:
+                stmt = insert(self.table).values(list(rows))
+                connection.execute(stmt)

--- a/sqlsynthgen/providers.py
+++ b/sqlsynthgen/providers.py
@@ -20,7 +20,10 @@ class ColumnValueProvider(BaseProvider):
         """Return a random value from the column specified."""
         query = select(orm_class).order_by(func.random()).limit(1)
         random_row = db_connection.execute(query).first()
-        return getattr(random_row, column_name)
+
+        if random_row:
+            return getattr(random_row, column_name)
+        return None
 
 
 class BytesProvider(BaseDataProvider):

--- a/tests/examples/example_config.yaml
+++ b/tests/examples/example_config.yaml
@@ -60,6 +60,8 @@ tables:
     vocabulary_table: true
   mitigation_type:
     vocabulary_table: true
+  empty_vocabulary:
+    vocabulary_table: true
 
 story_generators_module: story_generators
 story_generators:

--- a/tests/examples/src.dump
+++ b/tests/examples/src.dump
@@ -21,7 +21,7 @@ DROP DATABASE IF EXISTS src WITH (FORCE);
 -- Name: src; Type: DATABASE; Schema: -; Owner: postgres
 --
 
-CREATE DATABASE src WITH TEMPLATE = template0 ENCODING = 'UTF8' LOCALE = 'en_US.UTF-8';
+CREATE DATABASE src WITH TEMPLATE = template0 ENCODING = 'UTF8' LOCALE = 'en_US.utf8';
 
 
 ALTER DATABASE src OWNER TO postgres;

--- a/tests/examples/src.dump
+++ b/tests/examples/src.dump
@@ -113,11 +113,23 @@ CREATE TABLE public.no_pk_test (
 ALTER TABLE public.no_pk_test OWNER TO postgres;
 
 --
+-- Name: empty_dictionary; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.empty_dictionary (
+    entry_id integer NOT NULL,
+    entry_name text NOT NULL
+);
+
+ALTER TABLE public.empty_dictionary OWNER TO postgres;
+
+--
 -- Name: test_entity; Type: TABLE; Schema: public; Owner: postgres
 --
 
 CREATE TABLE public.test_entity (
-    single_letter_column VARCHAR(1)
+    single_letter_column VARCHAR(1),
+    dictionary_entry_id integer
 );
 
 ALTER TABLE public.test_entity OWNER TO postgres;
@@ -1186,6 +1198,13 @@ INSERT INTO public.person VALUES (1000, 'Randy Random', true, '2023-03-01 00:00:
 ALTER TABLE ONLY public.concept
     ADD CONSTRAINT concept_pkey PRIMARY KEY (concept_id);
 
+--
+-- Name: empty_dictionary empty_dictionary_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.empty_dictionary
+    ADD CONSTRAINT empty_dictionary_pkey PRIMARY KEY (entry_id);
+
 
 --
 -- Name: concept_type concept_type_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
@@ -1233,6 +1252,12 @@ CREATE INDEX fki_concept_concept_type_id_fkey ON public.concept USING btree (con
 ALTER TABLE ONLY public.concept
     ADD CONSTRAINT concept_concept_type_id_fkey FOREIGN KEY (concept_type_id) REFERENCES public.concept_type(id);
 
+--
+-- Name: test_entity test_entity_dictionary_entry_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.test_entity
+    ADD CONSTRAINT test_entity_dictionary_entry_id_fkey FOREIGN KEY (dictionary_entry_id) REFERENCES public.empty_dictionary(entry_id);
 
 --
 -- Name: concept_type concept_type_mitigation_type_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres

--- a/tests/examples/src.dump
+++ b/tests/examples/src.dump
@@ -21,7 +21,7 @@ DROP DATABASE IF EXISTS src WITH (FORCE);
 -- Name: src; Type: DATABASE; Schema: -; Owner: postgres
 --
 
-CREATE DATABASE src WITH TEMPLATE = template0 ENCODING = 'UTF8' LOCALE = 'en_US.utf8';
+CREATE DATABASE src WITH TEMPLATE = template0 ENCODING = 'UTF8' LOCALE = 'en_US.UTF-8';
 
 
 ALTER DATABASE src OWNER TO postgres;
@@ -113,15 +113,15 @@ CREATE TABLE public.no_pk_test (
 ALTER TABLE public.no_pk_test OWNER TO postgres;
 
 --
--- Name: empty_dictionary; Type: TABLE; Schema: public; Owner: postgres
+-- Name: empty_vocabulary; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.empty_dictionary (
+CREATE TABLE public.empty_vocabulary (
     entry_id integer NOT NULL,
     entry_name text NOT NULL
 );
 
-ALTER TABLE public.empty_dictionary OWNER TO postgres;
+ALTER TABLE public.empty_vocabulary OWNER TO postgres;
 
 --
 -- Name: test_entity; Type: TABLE; Schema: public; Owner: postgres
@@ -129,7 +129,7 @@ ALTER TABLE public.empty_dictionary OWNER TO postgres;
 
 CREATE TABLE public.test_entity (
     single_letter_column VARCHAR(1),
-    dictionary_entry_id integer
+    vocabulary_entry_id integer
 );
 
 ALTER TABLE public.test_entity OWNER TO postgres;
@@ -1199,11 +1199,11 @@ ALTER TABLE ONLY public.concept
     ADD CONSTRAINT concept_pkey PRIMARY KEY (concept_id);
 
 --
--- Name: empty_dictionary empty_dictionary_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: empty_vocabulary empty_vocabulary_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY public.empty_dictionary
-    ADD CONSTRAINT empty_dictionary_pkey PRIMARY KEY (entry_id);
+ALTER TABLE ONLY public.empty_vocabulary
+    ADD CONSTRAINT empty_vocabulary_pkey PRIMARY KEY (entry_id);
 
 
 --
@@ -1253,11 +1253,11 @@ ALTER TABLE ONLY public.concept
     ADD CONSTRAINT concept_concept_type_id_fkey FOREIGN KEY (concept_type_id) REFERENCES public.concept_type(id);
 
 --
--- Name: test_entity test_entity_dictionary_entry_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: test_entity test_entity_vocabulary_entry_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
 ALTER TABLE ONLY public.test_entity
-    ADD CONSTRAINT test_entity_dictionary_entry_id_fkey FOREIGN KEY (dictionary_entry_id) REFERENCES public.empty_dictionary(entry_id);
+    ADD CONSTRAINT test_entity_vocabulary_entry_id_fkey FOREIGN KEY (vocabulary_entry_id) REFERENCES public.empty_vocabulary(entry_id);
 
 --
 -- Name: concept_type concept_type_mitigation_type_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -152,6 +152,7 @@ class FunctionalTestCase(RequiresDBTestCase):
                 f"--ssg-file={self.alt_ssg_file_path}",
                 f"--config-file={self.config_file_path}",
                 f"--stats-file={self.stats_file_path}",
+                "--force",
             ],
             capture_output=True,
             env=self.env,

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -61,29 +61,20 @@ class FunctionalTestCase(RequiresDBTestCase):
 
         os.chdir(self.test_dir)
 
-        for file_path in (
-            self.orm_file_path,
-            self.ssg_file_path,
-            self.alt_orm_file_path,
-            self.alt_ssg_file_path,
-            self.stats_file_path,
-        ) + self.vocabulary_file_paths:
-            file_path.unlink(missing_ok=True)
-
     def tearDown(self) -> None:
         os.chdir(self.start_dir)
 
     def test_workflow_minimal_args(self) -> None:
         """Test the recommended CLI workflow runs without errors."""
         completed_process = run(
-            ["sqlsynthgen", "make-tables"],
+            ["sqlsynthgen", "make-tables", "--force"],
             capture_output=True,
             env=self.env,
         )
         self.assertSuccess(completed_process)
 
         completed_process = run(
-            ["sqlsynthgen", "make-generators"],
+            ["sqlsynthgen", "make-generators", "--force"],
             capture_output=True,
             env=self.env,
         )
@@ -122,6 +113,7 @@ class FunctionalTestCase(RequiresDBTestCase):
                 "sqlsynthgen",
                 "make-tables",
                 f"--orm-file={self.alt_orm_file_path}",
+                "--force",
             ],
             capture_output=True,
             env=self.env,
@@ -138,6 +130,7 @@ class FunctionalTestCase(RequiresDBTestCase):
                 "make-stats",
                 f"--stats-file={self.stats_file_path}",
                 f"--config-file={self.config_file_path}",
+                "--force",
             ],
             capture_output=True,
             env=self.env,

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,6 +1,7 @@
 """Tests for the providers module."""
 import datetime as dt
 from pathlib import Path
+from typing import Any
 
 from sqlalchemy import Column, Integer, Text, create_engine, insert
 from sqlalchemy.ext.declarative import declarative_base
@@ -47,7 +48,7 @@ class ColumnValueProviderTestCase(RequiresDBTestCase):
         )
         metadata.create_all(self.engine)
 
-    def test_column_value(self) -> None:
+    def test_column_value_present(self) -> None:
         """Test the key method."""
         # pylint: disable=invalid-name
 
@@ -59,6 +60,15 @@ class ColumnValueProviderTestCase(RequiresDBTestCase):
             key = provider.column_value(conn, Person, "sex")
 
         self.assertEqual("M", key)
+
+    def test_column_value_missing(self) -> None:
+        """Test the generator when there are no values in the source table."""
+
+        with self.engine.connect() as connection:
+            provider: providers.ColumnValueProvider = providers.ColumnValueProvider()
+            generated_value: Any = provider.column_value(connection, Person, "sex")
+
+        self.assertIsNone(generated_value)
 
 
 class TimedeltaProvider(SSGTestCase):


### PR DESCRIPTION
Before this, SSG failed. This was causing issues when using SSG on OMOP, where empty tables are common.