### PR TITLE
Make src & dst database params optionals

### DIFF
--- a/sqlsynthgen/create.py
+++ b/sqlsynthgen/create.py
@@ -70,18 +70,10 @@ def create_db_data(
         if settings.dst_schema
         else create_engine(settings.dst_postgres_dsn)
     )
-    src_engine = (
-        create_engine_with_search_path(
-            settings.src_postgres_dsn, settings.src_schema  # type: ignore
-        )
-        if settings.src_schema is not None
-        else create_engine(settings.src_postgres_dsn)
-    )
 
-    with dst_engine.connect() as dst_conn, src_engine.connect() as src_conn:
+    with dst_engine.connect() as dst_conn:
         for _ in range(num_passes):
             populate(
-                src_conn,
                 dst_conn,
                 sorted_tables,
                 table_generator_dict,
@@ -93,7 +85,6 @@ def _populate_story(
     story: Story,
     table_dict: Dict[str, Any],
     table_generator_dict: Dict[str, Any],
-    src_conn: Any,
     dst_conn: Any,
 ) -> None:
     """Write to the database all the rows created by the given story."""
@@ -107,7 +98,7 @@ def _populate_story(
             table = table_dict[table_name]
             if table.name in table_generator_dict:
                 table_generator = table_generator_dict[table.name]
-                default_values = table_generator(src_conn, dst_conn).__dict__
+                default_values = table_generator(dst_conn).__dict__
             else:
                 default_values = {}
             insert_values = {**default_values, **provided_values}
@@ -123,7 +114,6 @@ def _populate_story(
 
 
 def populate(
-    src_conn: Any,
     dst_conn: Any,
     tables: list,
     table_generator_dict: dict,
@@ -145,7 +135,7 @@ def populate(
     for story in stories:
         # Run the inserts for each story within a transaction.
         with dst_conn.begin():
-            _populate_story(story, table_dict, table_generator_dict, src_conn, dst_conn)
+            _populate_story(story, table_dict, table_generator_dict, dst_conn)
 
     # Generate individual rows, table by table.
     for table in tables:
@@ -157,7 +147,5 @@ def populate(
         # Run all the inserts for one table in a transaction
         with dst_conn.begin():
             for _ in range(table_generator.num_rows_per_pass):
-                stmt = insert(table).values(
-                    table_generator(src_conn, dst_conn).__dict__
-                )
+                stmt = insert(table).values(table_generator(dst_conn).__dict__)
                 dst_conn.execute(stmt)

--- a/sqlsynthgen/templates/ssg.py.j2
+++ b/sqlsynthgen/templates/ssg.py.j2
@@ -32,7 +32,7 @@ with open("{{ src_stats_filename }}", "r", encoding="utf-8") as f:
 class {{ table_data.class_name }}:
     num_rows_per_pass = {{ table_data.rows_per_pass }}
 
-    def __init__(self, src_db_conn, dst_db_conn):
+    def __init__(self, dst_db_conn):
     {% for column_data in table_data.columns %}
         {% if column_data.primary_key %}
         pass

--- a/tests/examples/expected_ssg.py
+++ b/tests/examples/expected_ssg.py
@@ -36,14 +36,14 @@ concept_vocab = FileUploader(tests.examples.example_orm.Concept.__table__)
 class entityGenerator:
     num_rows_per_pass = 1
 
-    def __init__(self, src_db_conn, dst_db_conn):
+    def __init__(self, dst_db_conn):
         pass
 
 
 class personGenerator:
     num_rows_per_pass = 2
 
-    def __init__(self, src_db_conn, dst_db_conn):
+    def __init__(self, dst_db_conn):
         self.name = generic.person.full_name()
         self.stored_from = generic.datetime.datetime(start=2022, end=2022)
         self.research_opt_out = row_generators.boolean_from_src_stats_generator(
@@ -57,7 +57,7 @@ class personGenerator:
 class test_entityGenerator:
     num_rows_per_pass = 1
 
-    def __init__(self, src_db_conn, dst_db_conn):
+    def __init__(self, dst_db_conn):
         pass
         self.single_letter_column = generic.person.password(1)
 
@@ -65,7 +65,7 @@ class test_entityGenerator:
 class hospital_visitGenerator:
     num_rows_per_pass = 3
 
-    def __init__(self, src_db_conn, dst_db_conn):
+    def __init__(self, dst_db_conn):
         (
             self.visit_start,
             self.visit_end,

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -62,7 +62,6 @@ class MyTestCase(SSGTestCase):
             return story()
 
         for num_stories_per_pass, num_rows_per_pass in itt.product([0, 2], [0, 3]):
-            mock_src_conn = MagicMock()
             mock_dst_conn = MagicMock()
             mock_dst_conn.execute.return_value.returned_defaults = {}
             mock_table = MagicMock()
@@ -78,13 +77,10 @@ class MyTestCase(SSGTestCase):
                 if num_stories_per_pass > 0
                 else []
             )
-            populate(
-                mock_src_conn, mock_dst_conn, tables, row_generators, story_generators
-            )
+            populate(mock_dst_conn, tables, row_generators, story_generators)
 
             mock_gen.assert_has_calls(
-                [call(mock_src_conn, mock_dst_conn)]
-                * (num_stories_per_pass + num_rows_per_pass)
+                [call(mock_dst_conn)] * (num_stories_per_pass + num_rows_per_pass)
             )
             mock_insert.return_value.values.assert_has_calls(
                 [call(mock_gen.return_value.__dict__)]
@@ -110,7 +106,7 @@ class MyTestCase(SSGTestCase):
         tables = [mock_table_one, mock_table_two, mock_table_three]
         row_generators = {"two": mock_gen_two, "three": mock_gen_three}
 
-        populate(2, mock_dst_conn, tables, row_generators, [])
+        populate(mock_dst_conn, tables, row_generators, [])
         self.assertListEqual(
             [call(mock_table_two), call(mock_table_three)], mock_insert.call_args_list
         )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -80,6 +80,23 @@ class TestCLI(SSGTestCase):
         )
         self.assertEqual(1, result.exit_code)
 
+    @patch("sqlsynthgen.main.stderr", new_callable=StringIO)
+    def test_make_generators_errors_if_src_dsn_missing(
+        self, mock_stderr: MagicMock
+    ) -> None:
+        """Test the make-generators sub-command with missing db params."""
+        result = runner.invoke(
+            app,
+            [
+                "make-generators",
+            ],
+            catch_exceptions=False,
+        )
+        self.assertEqual(
+            "Missing source database connection details.\n", mock_stderr.getvalue()
+        )
+        self.assertEqual(1, result.exit_code)
+
     @patch("sqlsynthgen.main.Path")
     @patch("sqlsynthgen.main.import_file")
     @patch("sqlsynthgen.main.make_table_generators")
@@ -204,6 +221,24 @@ class TestCLI(SSGTestCase):
         )
         self.assertEqual(1, result.exit_code)
 
+    @patch("sqlsynthgen.main.stderr", new_callable=StringIO)
+    def test_make_tables_errors_if_src_dsn_missing(
+        self, mock_stderr: MagicMock
+    ) -> None:
+        """Test the make-tables sub-command doesn't overwrite."""
+
+        result = runner.invoke(
+            app,
+            [
+                "make-tables",
+            ],
+            catch_exceptions=False,
+        )
+        self.assertEqual(
+            "Missing source database connection details.\n", mock_stderr.getvalue()
+        )
+        self.assertEqual(1, result.exit_code)
+
     @patch("sqlsynthgen.main.make_tables_file")
     @patch("sqlsynthgen.main.get_settings")
     @patch("sqlsynthgen.main.Path")
@@ -288,6 +323,28 @@ class TestCLI(SSGTestCase):
         )
         self.assertEqual(
             f"{output_path} should not already exist. Exiting...\n",
+            mock_stderr.getvalue(),
+        )
+        self.assertEqual(1, result.exit_code)
+
+    @patch("sqlsynthgen.main.stderr", new_callable=StringIO)
+    def test_make_stats_errors_if_no_src_dsn(
+        self,
+        mock_stderr: MagicMock,
+    ) -> None:
+        """Test the make-stats sub-command with missing settings."""
+        example_conf_path = "tests/examples/example_config.yaml"
+
+        result = runner.invoke(
+            app,
+            [
+                "make-stats",
+                f"--config-file={example_conf_path}",
+            ],
+            catch_exceptions=False,
+        )
+        self.assertEqual(
+            "Missing source database connection details.\n",
             mock_stderr.getvalue(),
         )
         self.assertEqual(1, result.exit_code)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -33,15 +33,21 @@ class TestCLI(SSGTestCase):
         mock_create.assert_called_once_with(mock_import.return_value.vocab_dict)
         self.assertSuccess(result)
 
+    @patch("sqlsynthgen.main.get_settings")
     @patch("sqlsynthgen.main.import_file")
     @patch("sqlsynthgen.main.Path")
     @patch("sqlsynthgen.main.make_table_generators")
     def test_make_generators(
-        self, mock_make: MagicMock, mock_path: MagicMock, mock_import: MagicMock
+        self,
+        mock_make: MagicMock,
+        mock_path: MagicMock,
+        mock_import: MagicMock,
+        mock_settings: MagicMock,
     ) -> None:
         """Test the make-generators sub-command."""
         mock_path.return_value.exists.return_value = False
         mock_make.return_value = "some text"
+        mock_settings.return_value.src_postges_dsn = ""
 
         result = runner.invoke(
             app,
@@ -97,16 +103,22 @@ class TestCLI(SSGTestCase):
         )
         self.assertEqual(1, result.exit_code)
 
+    @patch("sqlsynthgen.main.get_settings")
     @patch("sqlsynthgen.main.Path")
     @patch("sqlsynthgen.main.import_file")
     @patch("sqlsynthgen.main.make_table_generators")
     def test_make_generators_with_force_enabled(
-        self, mock_make: MagicMock, mock_import: MagicMock, mock_path: MagicMock
+        self,
+        mock_make: MagicMock,
+        mock_import: MagicMock,
+        mock_path: MagicMock,
+        mock_settings: MagicMock,
     ) -> None:
         """Tests the make-generators sub-commands overwrite files when instructed."""
 
         mock_path.return_value.exists.return_value = True
         mock_make.return_value = "make result"
+        mock_settings.return_value.src_postges_dsn = ""
 
         for force_option in ["--force", "-f"]:
             with self.subTest(f"Using option {force_option}"):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -6,32 +6,19 @@ from tests.utils import SSGTestCase
 class TestSettings(SSGTestCase):
     """Tests for the Settings class."""
 
-    def test_default_settings(self) -> None:
+    def test_minimal_settings(self) -> None:
         """Test the minimal settings."""
         settings = Settings(
-            src_host_name="shost",
-            src_user_name="suser",
-            src_password="spassword",
-            src_db_name="sdbname",
-            dst_host_name="dhost",
-            dst_user_name="duser",
-            dst_password="dpassword",
-            dst_db_name="ddbname",
             # To stop any local .env files influencing the test
             _env_file=None,
         )
+        self.assertIsNone(settings.src_postgres_dsn)
+        self.assertEqual(5432, settings.src_port)
+        self.assertEqual(False, settings.src_ssl_required)
 
-        self.assertEqual(
-            "postgresql://suser:spassword@shost:5432/sdbname",
-            str(settings.src_postgres_dsn),
-        )
-        self.assertIsNone(settings.src_schema)
-        self.assertIsNone(settings.dst_schema)
-
-        self.assertEqual(
-            "postgresql://duser:dpassword@dhost:5432/ddbname",
-            str(settings.dst_postgres_dsn),
-        )
+        self.assertIsNone(settings.dst_postgres_dsn)
+        self.assertEqual(5432, settings.dst_port)
+        self.assertEqual(False, settings.dst_ssl_required)
 
     def test_maximal_settings(self) -> None:
         """Test the full settings."""
@@ -60,5 +47,32 @@ class TestSettings(SSGTestCase):
 
         self.assertEqual(
             "postgresql://duser:dpassword@dhost:4321/ddbname?sslmode=require",
+            str(settings.dst_postgres_dsn),
+        )
+
+    def test_typical_settings(self) -> None:
+        """Test that we can make src and dst Postgres DSNs."""
+        settings = Settings(
+            src_host_name="shost",
+            src_user_name="suser",
+            src_password="spassword",
+            src_db_name="sdbname",
+            dst_host_name="dhost",
+            dst_user_name="duser",
+            dst_password="dpassword",
+            dst_db_name="ddbname",
+            # To stop any local .env files influencing the test
+            _env_file=None,
+        )
+
+        self.assertEqual(
+            "postgresql://suser:spassword@shost:5432/sdbname",
+            str(settings.src_postgres_dsn),
+        )
+        self.assertIsNone(settings.src_schema)
+        self.assertIsNone(settings.dst_schema)
+
+        self.assertEqual(
+            "postgresql://duser:dpassword@dhost:5432/ddbname",
             str(settings.dst_postgres_dsn),
         )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -80,9 +80,3 @@ class SSGTestCase(TestCase):
 @skipUnless(os.environ.get("REQUIRES_DB") == "1", "Set 'REQUIRES_DB=1' to enable.")
 class RequiresDBTestCase(SSGTestCase):
     """A test case that only runs if REQUIRES_DB has been set to 1."""
-
-    def setUp(self) -> None:
-        pass
-
-    def tearDown(self) -> None:
-        pass


### PR DESCRIPTION
The user who runs the make- commands and the user who runs the create- commands may be different people. Therefore, it makes sense to make the db connection parameters optional.

There may be a neater way to do this (e.g. it might be better to validate on first use rather than in the `make_xyz` functions in `main.py`) but I think the current method still works.

Would it be best to also explicitly check for the dst db params in the `create_` funcs in `main.py`? At the moment, we don't.