### PR TITLE
Rm commands

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -1,23 +1,27 @@
 Quick Start
 ===========
 
-After :ref:`Installation <enduser>`, we can run sqlsynthgen with the `--help` option to see the available commands:
+After :ref:`Installation <enduser>`, we can run ``sqlsynthgen`` to see the available commands:
 
 .. code-block:: console
 
-   $ sqlsynthgen --help
+   $ sqlsynthgen
    Usage: sqlsynthgen [OPTIONS] COMMAND [ARGS]...
 
    Options:
-     --help           Show this message and exit.
+     --help                          Show this message and exit.
 
    Commands:
      create-data      Populate schema with synthetic data.
      create-tables    Create schema from Python classes.
      create-vocab     Create tables using the SQLAlchemy file.
      make-generators  Make a SQLSynthGen file of generator classes.
-     make-stats       Compute summary statistics from the source database,...
+     make-stats       Compute summary statistics from the source database.
      make-tables      Make a SQLAlchemy file of Table classes.
+     remove-data      Truncate all non-vocabulary tables in the dst schema.
+     remove-tables    Drop all tables in the dst schema.
+     remove-vocab     Truncate all vocabulary tables in the dst schema.
+     validate-config  Validate the format of a config file.
 
 For the simplest case, we will need `make-tables`, `make-generators`, `create-tables` and `create-data` but, first,
 we need to set environment variables to tell sqlsynthgen how to access our source database (where the real data resides now) and destination database (where the synthetic data will go).

--- a/sqlsynthgen/main.py
+++ b/sqlsynthgen/main.py
@@ -13,7 +13,7 @@ from jsonschema.validators import validate
 
 from sqlsynthgen.create import create_db_data, create_db_tables, create_db_vocab
 from sqlsynthgen.make import make_src_stats, make_table_generators, make_tables_file
-from sqlsynthgen.remove import remove_db_data
+from sqlsynthgen.remove import remove_db_data, remove_db_vocab
 from sqlsynthgen.settings import get_settings
 from sqlsynthgen.utils import import_file, read_yaml_file
 
@@ -230,6 +230,17 @@ def remove_data(
     orm_module = import_file(orm_file)
     ssg_module = import_file(ssg_file)
     remove_db_data(orm_module, ssg_module)
+
+
+@app.command()
+def remove_vocab(
+    orm_file: str = typer.Option(ORM_FILENAME),
+    ssg_file: str = typer.Option(SSG_FILENAME),
+) -> None:
+    """Truncate all the vocabulary tables in the destination DB."""
+    orm_module = import_file(orm_file)
+    ssg_module = import_file(ssg_file)
+    remove_db_vocab(orm_module, ssg_module)
 
 
 if __name__ == "__main__":

--- a/sqlsynthgen/main.py
+++ b/sqlsynthgen/main.py
@@ -13,6 +13,7 @@ from jsonschema.validators import validate
 
 from sqlsynthgen.create import create_db_data, create_db_tables, create_db_vocab
 from sqlsynthgen.make import make_src_stats, make_table_generators, make_tables_file
+from sqlsynthgen.remove import remove_db_data
 from sqlsynthgen.settings import get_settings
 from sqlsynthgen.utils import import_file, read_yaml_file
 
@@ -218,6 +219,17 @@ def validate_config(config_file: Path) -> None:
     except ValidationError as e:
         typer.echo(e, err=True)
         sys.exit(1)
+
+
+@app.command()
+def remove_data(
+    orm_file: str = typer.Option(ORM_FILENAME),
+    ssg_file: str = typer.Option(SSG_FILENAME),
+) -> None:
+    """Truncate all the non-vocabulary tables in the destination DB."""
+    orm_module = import_file(orm_file)
+    ssg_module = import_file(ssg_file)
+    remove_db_data(orm_module, ssg_module)
 
 
 if __name__ == "__main__":

--- a/sqlsynthgen/main.py
+++ b/sqlsynthgen/main.py
@@ -227,34 +227,46 @@ def validate_config(config_file: Path) -> None:
 def remove_data(
     orm_file: str = typer.Option(ORM_FILENAME),
     ssg_file: str = typer.Option(SSG_FILENAME),
+    yes: bool = typer.Option(False, "--yes", prompt="Are you sure?"),
 ) -> None:
     """Truncate non-vocabulary tables in the destination schema."""
-    orm_module = import_file(orm_file)
-    ssg_module = import_file(ssg_file)
-    remove_db_data(orm_module, ssg_module)
+    if yes:
+        orm_module = import_file(orm_file)
+        ssg_module = import_file(ssg_file)
+        remove_db_data(orm_module, ssg_module)
+    else:
+        typer.echo("Would truncate non-vocabulary tables if called with --yes")
 
 
 @app.command()
 def remove_vocab(
     orm_file: str = typer.Option(ORM_FILENAME),
     ssg_file: str = typer.Option(SSG_FILENAME),
+    yes: bool = typer.Option(False, "--yes", prompt="Are you sure?"),
 ) -> None:
     """Truncate vocabulary tables in the destination schema."""
-    orm_module = import_file(orm_file)
-    ssg_module = import_file(ssg_file)
-    remove_db_vocab(orm_module, ssg_module)
+    if yes:
+        orm_module = import_file(orm_file)
+        ssg_module = import_file(ssg_file)
+        remove_db_vocab(orm_module, ssg_module)
+    else:
+        typer.echo("Would truncate vocabulary tables if called with --yes")
 
 
 @app.command()
 def remove_tables(
     orm_file: str = typer.Option(ORM_FILENAME),
+    yes: bool = typer.Option(False, "--yes", prompt="Are you sure?"),
 ) -> None:
     """Drop all tables in the destination schema.
 
     Does not drop the schema itself.
     """
-    orm_module = import_file(orm_file)
-    remove_db_tables(orm_module)
+    if yes:
+        orm_module = import_file(orm_file)
+        remove_db_tables(orm_module)
+    else:
+        typer.echo("Would remove tables if called with --yes")
 
 
 if __name__ == "__main__":

--- a/sqlsynthgen/main.py
+++ b/sqlsynthgen/main.py
@@ -23,7 +23,7 @@ CONFIG_SCHEMA_PATH: Final[Path] = (
     Path(__file__).parent / "json_schemas/config_schema.json"
 )
 
-app = typer.Typer()
+app = typer.Typer(no_args_is_help=True)
 
 
 @app.command()

--- a/sqlsynthgen/main.py
+++ b/sqlsynthgen/main.py
@@ -151,7 +151,9 @@ def make_stats(
     stats_file: str = typer.Option(STATS_FILENAME),
     force: bool = typer.Option(False, "--force", "-f"),
 ) -> None:
-    """Compute summary statistics from the source database, write them to a YAML file.
+    """Compute summary statistics from the source database.
+
+    Writes the statistics to a YAML file.
 
     Example:
         $ sqlsynthgen make_stats --config-file=example_config.yaml
@@ -226,7 +228,7 @@ def remove_data(
     orm_file: str = typer.Option(ORM_FILENAME),
     ssg_file: str = typer.Option(SSG_FILENAME),
 ) -> None:
-    """Truncate all the non-vocabulary tables in the destination DB."""
+    """Truncate non-vocabulary tables in the destination schema."""
     orm_module = import_file(orm_file)
     ssg_module = import_file(ssg_file)
     remove_db_data(orm_module, ssg_module)
@@ -237,7 +239,7 @@ def remove_vocab(
     orm_file: str = typer.Option(ORM_FILENAME),
     ssg_file: str = typer.Option(SSG_FILENAME),
 ) -> None:
-    """Truncate all the vocabulary tables in the destination DB."""
+    """Truncate vocabulary tables in the destination schema."""
     orm_module = import_file(orm_file)
     ssg_module = import_file(ssg_file)
     remove_db_vocab(orm_module, ssg_module)
@@ -247,7 +249,10 @@ def remove_vocab(
 def remove_tables(
     orm_file: str = typer.Option(ORM_FILENAME),
 ) -> None:
-    """Drop the tables (but not the schema)."""
+    """Drop all tables in the destination schema.
+
+    Does not drop the schema itself.
+    """
     orm_module = import_file(orm_file)
     remove_db_tables(orm_module)
 

--- a/sqlsynthgen/main.py
+++ b/sqlsynthgen/main.py
@@ -13,7 +13,7 @@ from jsonschema.validators import validate
 
 from sqlsynthgen.create import create_db_data, create_db_tables, create_db_vocab
 from sqlsynthgen.make import make_src_stats, make_table_generators, make_tables_file
-from sqlsynthgen.remove import remove_db_data, remove_db_vocab
+from sqlsynthgen.remove import remove_db_data, remove_db_tables, remove_db_vocab
 from sqlsynthgen.settings import get_settings
 from sqlsynthgen.utils import import_file, read_yaml_file
 
@@ -241,6 +241,15 @@ def remove_vocab(
     orm_module = import_file(orm_file)
     ssg_module = import_file(ssg_file)
     remove_db_vocab(orm_module, ssg_module)
+
+
+@app.command()
+def remove_tables(
+    orm_file: str = typer.Option(ORM_FILENAME),
+) -> None:
+    """Drop the tables (but not the schema)."""
+    orm_module = import_file(orm_file)
+    remove_db_tables(orm_module)
 
 
 if __name__ == "__main__":

--- a/sqlsynthgen/providers.py
+++ b/sqlsynthgen/providers.py
@@ -56,7 +56,7 @@ class TimedeltaProvider(BaseProvider):
         """Return a random timedelta object."""
         min_s = min_dt.total_seconds()
         max_s = max_dt.total_seconds()
-        seconds = random.randint(min_s, max_s)
+        seconds = random.randint(int(min_s), int(max_s))
         return dt.timedelta(seconds=seconds)
 
 

--- a/sqlsynthgen/remove.py
+++ b/sqlsynthgen/remove.py
@@ -11,7 +11,7 @@ def remove_db_data(orm_module: ModuleType, ssg_module: ModuleType) -> None:
     """Truncate the synthetic data tables but not the vocabularies."""
     settings = get_settings()
 
-    assert settings.dst_postgres_dsn
+    assert settings.dst_postgres_dsn, "Missing destination database settings"
     dst_engine = create_db_engine(
         settings.dst_postgres_dsn, schema_name=settings.dst_schema
     )

--- a/sqlsynthgen/remove.py
+++ b/sqlsynthgen/remove.py
@@ -33,8 +33,10 @@ def remove_db_vocab(orm_module: ModuleType, ssg_module: ModuleType) -> None:
     )
 
     with dst_engine.connect() as dst_conn:
-        for table_name in ssg_module.vocab_dict.keys():
-            dst_conn.execute(delete(orm_module.Base.metadata.tables[table_name]))
+        for table in reversed(orm_module.Base.metadata.sorted_tables):
+            # We presume that all tables that are vocab should be truncated
+            if table.name in ssg_module.vocab_dict:
+                dst_conn.execute(delete(table))
 
 
 def remove_db_tables(orm_module: ModuleType) -> None:

--- a/sqlsynthgen/remove.py
+++ b/sqlsynthgen/remove.py
@@ -35,3 +35,16 @@ def remove_db_vocab(orm_module: ModuleType, ssg_module: ModuleType) -> None:
     with dst_engine.connect() as dst_conn:
         for table_name in ssg_module.vocab_dict.keys():
             dst_conn.execute(delete(orm_module.Base.metadata.tables[table_name]))
+
+
+def remove_db_tables(orm_module: ModuleType) -> None:
+    """Drop the tables in the destination schema."""
+    settings = get_settings()
+
+    assert settings.dst_postgres_dsn, "Missing destination database settings"
+    dst_engine = create_db_engine(
+        settings.dst_postgres_dsn, schema_name=settings.dst_schema
+    )
+
+    metadata = orm_module.Base.metadata
+    metadata.drop_all(dst_engine)

--- a/sqlsynthgen/remove.py
+++ b/sqlsynthgen/remove.py
@@ -1,0 +1,23 @@
+"""Functions and classes to undo the operations in create.py."""
+from types import ModuleType
+
+from sqlalchemy import delete
+
+from sqlsynthgen.settings import get_settings
+from sqlsynthgen.utils import create_db_engine
+
+
+def remove_db_data(orm_module: ModuleType, ssg_module: ModuleType) -> None:
+    """Truncate the synthetic data tables but not the vocabularies."""
+    settings = get_settings()
+
+    assert settings.dst_postgres_dsn
+    dst_engine = create_db_engine(
+        settings.dst_postgres_dsn, schema_name=settings.dst_schema
+    )
+
+    with dst_engine.connect() as dst_conn:
+        for table in reversed(orm_module.Base.metadata.sorted_tables):
+            # We presume that all tables that aren't vocab should be truncated
+            if table.name not in ssg_module.vocab_dict:
+                dst_conn.execute(delete(table))

--- a/sqlsynthgen/remove.py
+++ b/sqlsynthgen/remove.py
@@ -21,3 +21,17 @@ def remove_db_data(orm_module: ModuleType, ssg_module: ModuleType) -> None:
             # We presume that all tables that aren't vocab should be truncated
             if table.name not in ssg_module.vocab_dict:
                 dst_conn.execute(delete(table))
+
+
+def remove_db_vocab(orm_module: ModuleType, ssg_module: ModuleType) -> None:
+    """Truncate the vocabulary tables."""
+    settings = get_settings()
+
+    assert settings.dst_postgres_dsn, "Missing destination database settings"
+    dst_engine = create_db_engine(
+        settings.dst_postgres_dsn, schema_name=settings.dst_schema
+    )
+
+    with dst_engine.connect() as dst_conn:
+        for table_name in ssg_module.vocab_dict.keys():
+            dst_conn.execute(delete(orm_module.Base.metadata.tables[table_name]))

--- a/tests/examples/example_orm.py
+++ b/tests/examples/example_orm.py
@@ -20,7 +20,6 @@ metadata = Base.metadata
 
 class Person(Base):
     __tablename__ = "person"
-    __table_args__ = {"schema": "myschema"}
 
     person_id = Column(
         Integer,
@@ -35,13 +34,12 @@ class Person(Base):
 
 class HopsitalVisit(Base):
     __tablename__ = "hospital_visit"
-    __table_args__ = {"schema": "myschema"}
 
     hospital_visit_id = Column(
         BigInteger,
         primary_key=True,
     )
-    person_id = Column(ForeignKey("myschema.person.person_id"))
+    person_id = Column(ForeignKey("person.person_id"))
     visit_start = Column(DateTime(True))
     visit_end = Column(Date)
     visit_duration_seconds = Column(Float)
@@ -50,7 +48,6 @@ class HopsitalVisit(Base):
 
 class Entity(Base):
     __tablename__ = "entity"
-    __table_args__ = {"schema": "myschema"}
 
     # NB Do not add any more columns to this table as
     # we use it to test what happens in the one-column case
@@ -62,7 +59,6 @@ class Entity(Base):
 
 class TestEntity(Base):
     __tablename__ = "test_entity"
-    __table_args__ = {"schema": "myschema"}
 
     test_entity_id = Column(
         Integer,
@@ -74,7 +70,6 @@ class TestEntity(Base):
 
 class Concept(Base):
     __tablename__ = "concept"
-    __table_args__ = {"schema": "myschema"}
 
     concept_id = Column(
         Integer,

--- a/tests/examples/remove_ssg.py
+++ b/tests/examples/remove_ssg.py
@@ -1,0 +1,7 @@
+"""For testing the remove commands."""
+import tests.examples.example_orm
+
+
+vocab_dict = {
+    "concept": None,
+}

--- a/tests/examples/remove_ssg.py
+++ b/tests/examples/remove_ssg.py
@@ -1,6 +1,4 @@
 """For testing the remove commands."""
-import tests.examples.example_orm
-
 
 vocab_dict = {
     "concept": None,

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -113,6 +113,14 @@ class FunctionalTestCase(RequiresDBTestCase):
         self.assertEqual("", completed_process.stderr.decode("utf-8"))
         self.assertSuccess(completed_process)
 
+        completed_process = run(
+            ["sqlsynthgen", "remove-vocab"],
+            capture_output=True,
+            env=self.env,
+        )
+        self.assertEqual("", completed_process.stderr.decode("utf-8"))
+        self.assertSuccess(completed_process)
+
     def test_workflow_maximal_args(self) -> None:
         """Test the CLI workflow runs with optional arguments."""
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -121,6 +121,14 @@ class FunctionalTestCase(RequiresDBTestCase):
         self.assertEqual("", completed_process.stderr.decode("utf-8"))
         self.assertSuccess(completed_process)
 
+        completed_process = run(
+            ["sqlsynthgen", "remove-tables"],
+            capture_output=True,
+            env=self.env,
+        )
+        self.assertEqual("", completed_process.stderr.decode("utf-8"))
+        self.assertSuccess(completed_process)
+
     def test_workflow_maximal_args(self) -> None:
         """Test the CLI workflow runs with optional arguments."""
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -105,6 +105,14 @@ class FunctionalTestCase(RequiresDBTestCase):
         self.assertEqual("", completed_process.stderr.decode("utf-8"))
         self.assertSuccess(completed_process)
 
+        completed_process = run(
+            ["sqlsynthgen", "remove-data"],
+            capture_output=True,
+            env=self.env,
+        )
+        self.assertEqual("", completed_process.stderr.decode("utf-8"))
+        self.assertSuccess(completed_process)
+
     def test_workflow_maximal_args(self) -> None:
         """Test the CLI workflow runs with optional arguments."""
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -109,6 +109,7 @@ class FunctionalTestCase(RequiresDBTestCase):
             ["sqlsynthgen", "remove-data"],
             capture_output=True,
             env=self.env,
+            input=b"\n",  # To select the default prompt option
         )
         self.assertEqual("", completed_process.stderr.decode("utf-8"))
         self.assertSuccess(completed_process)
@@ -117,6 +118,7 @@ class FunctionalTestCase(RequiresDBTestCase):
             ["sqlsynthgen", "remove-vocab"],
             capture_output=True,
             env=self.env,
+            input=b"\n",  # To select the default prompt option
         )
         self.assertEqual("", completed_process.stderr.decode("utf-8"))
         self.assertSuccess(completed_process)
@@ -125,6 +127,7 @@ class FunctionalTestCase(RequiresDBTestCase):
             ["sqlsynthgen", "remove-tables"],
             capture_output=True,
             env=self.env,
+            input=b"\n",  # To select the default prompt option
         )
         self.assertEqual("", completed_process.stderr.decode("utf-8"))
         self.assertSuccess(completed_process)
@@ -209,6 +212,30 @@ class FunctionalTestCase(RequiresDBTestCase):
                 f"--ssg-file={self.alt_ssg_file_path}",
                 "--num-passes=2",
             ],
+            capture_output=True,
+            env=self.env,
+        )
+        self.assertEqual("", completed_process.stderr.decode("utf-8"))
+        self.assertSuccess(completed_process)
+
+        completed_process = run(
+            ["sqlsynthgen", "remove-data", "--yes"],
+            capture_output=True,
+            env=self.env,
+        )
+        self.assertEqual("", completed_process.stderr.decode("utf-8"))
+        self.assertSuccess(completed_process)
+
+        completed_process = run(
+            ["sqlsynthgen", "remove-vocab", "--yes"],
+            capture_output=True,
+            env=self.env,
+        )
+        self.assertEqual("", completed_process.stderr.decode("utf-8"))
+        self.assertSuccess(completed_process)
+
+        completed_process = run(
+            ["sqlsynthgen", "remove-tables", "--yes"],
             capture_output=True,
             env=self.env,
         )

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -219,7 +219,13 @@ class FunctionalTestCase(RequiresDBTestCase):
         self.assertSuccess(completed_process)
 
         completed_process = run(
-            ["sqlsynthgen", "remove-data", "--yes"],
+            [
+                "sqlsynthgen",
+                "remove-data",
+                "--yes",
+                f"--orm-file={self.alt_orm_file_path}",
+                f"--ssg-file={self.alt_ssg_file_path}",
+            ],
             capture_output=True,
             env=self.env,
         )
@@ -227,7 +233,13 @@ class FunctionalTestCase(RequiresDBTestCase):
         self.assertSuccess(completed_process)
 
         completed_process = run(
-            ["sqlsynthgen", "remove-vocab", "--yes"],
+            [
+                "sqlsynthgen",
+                "remove-vocab",
+                "--yes",
+                f"--orm-file={self.alt_orm_file_path}",
+                f"--ssg-file={self.alt_ssg_file_path}",
+            ],
             capture_output=True,
             env=self.env,
         )
@@ -235,7 +247,12 @@ class FunctionalTestCase(RequiresDBTestCase):
         self.assertSuccess(completed_process)
 
         completed_process = run(
-            ["sqlsynthgen", "remove-tables", "--yes"],
+            [
+                "sqlsynthgen",
+                "remove-tables",
+                "--yes",
+                f"--orm-file={self.alt_orm_file_path}",
+            ],
             capture_output=True,
             env=self.env,
         )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -431,3 +431,17 @@ class TestCLI(SSGTestCase):
         )
         self.assertEqual(0, result.exit_code)
         mock_remove.assert_called_once_with(1, 2)
+
+    @patch("sqlsynthgen.main.remove_db_vocab")
+    @patch("sqlsynthgen.main.import_file", side_effect=(1, 2))
+    def test_remove_vocab(self, _: MagicMock, mock_remove: MagicMock) -> None:
+        """Test the remove-vocab command."""
+        result = runner.invoke(
+            app,
+            [
+                "remove-vocab",
+            ],
+            catch_exceptions=False,
+        )
+        self.assertEqual(0, result.exit_code)
+        mock_remove.assert_called_once_with(1, 2)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -424,9 +424,7 @@ class TestCLI(SSGTestCase):
         """Test the remove-data command."""
         result = runner.invoke(
             app,
-            [
-                "remove-data",
-            ],
+            ["remove-data", "--yes"],
             catch_exceptions=False,
         )
         self.assertEqual(0, result.exit_code)
@@ -438,9 +436,7 @@ class TestCLI(SSGTestCase):
         """Test the remove-vocab command."""
         result = runner.invoke(
             app,
-            [
-                "remove-vocab",
-            ],
+            ["remove-vocab", "--yes"],
             catch_exceptions=False,
         )
         self.assertEqual(0, result.exit_code)
@@ -452,9 +448,7 @@ class TestCLI(SSGTestCase):
         """Test the remove-tables command."""
         result = runner.invoke(
             app,
-            [
-                "remove-tables",
-            ],
+            ["remove-tables", "--yes"],
             catch_exceptions=False,
         )
         self.assertEqual(0, result.exit_code)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -445,3 +445,17 @@ class TestCLI(SSGTestCase):
         )
         self.assertEqual(0, result.exit_code)
         mock_remove.assert_called_once_with(1, 2)
+
+    @patch("sqlsynthgen.main.remove_db_tables")
+    @patch("sqlsynthgen.main.import_file", side_effect=(1,))
+    def test_remove_tables(self, _: MagicMock, mock_remove: MagicMock) -> None:
+        """Test the remove-tables command."""
+        result = runner.invoke(
+            app,
+            [
+                "remove-tables",
+            ],
+            catch_exceptions=False,
+        )
+        self.assertEqual(0, result.exit_code)
+        mock_remove.assert_called_once_with(1)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -417,3 +417,17 @@ class TestCLI(SSGTestCase):
         )
 
         self.assertEqual(1, result.exit_code)
+
+    @patch("sqlsynthgen.main.remove_db_data")
+    @patch("sqlsynthgen.main.import_file", side_effect=(1, 2))
+    def test_remove_data(self, _: MagicMock, mock_remove: MagicMock) -> None:
+        """Test the remove-data command."""
+        result = runner.invoke(
+            app,
+            [
+                "remove-data",
+            ],
+            catch_exceptions=False,
+        )
+        self.assertEqual(0, result.exit_code)
+        mock_remove.assert_called_once_with(1, 2)

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -85,7 +85,7 @@ class TestMakeGenerators(SSGTestCase):
 
         mock_create.assert_called_once()
         self.assertEqual(
-            "myschema.concept.yaml already exists. Exiting...\n", mock_stderr.getvalue()
+            "concept.yaml already exists. Exiting...\n", mock_stderr.getvalue()
         )
 
     @patch("sqlsynthgen.make.download_table")

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -1,0 +1,35 @@
+"""Tests for the remove module."""
+from unittest.mock import MagicMock, call, patch
+
+from sqlsynthgen.remove import remove_db_data
+from tests.examples import example_orm, remove_ssg
+from tests.utils import SSGTestCase
+
+
+class RemoveTestCase(SSGTestCase):
+    """Tests for removing data, vocabs and tables."""
+
+    @patch("sqlsynthgen.remove.create_db_engine")
+    @patch("sqlsynthgen.remove.delete", side_effect=(9, 8, 7, 6))
+    def test_remove_db_data(
+        self, mock_delete: MagicMock, mock_engine: MagicMock
+    ) -> None:
+        """Test the remove_db_data function."""
+        remove_db_data(example_orm, remove_ssg)
+        mock_delete.assert_has_calls(
+            [
+                call(example_orm.Base.metadata.tables["myschema." + t])
+                for t in ("hospital_visit", "test_entity", "person", "entity")
+            ]
+        )
+        dst_engine = mock_engine.return_value
+        dst_conn = dst_engine.connect.return_value.__enter__.return_value
+        dst_conn.execute.assert_has_calls([call(x) for x in (9, 8, 7, 6)])
+
+    def test_remove_db_vocab(self) -> None:
+        """Test the remove_db_vocab function."""
+        # ToDo
+
+    def test_remove_tables(self) -> None:
+        """Test the remove_db_tables function."""
+        # ToDo

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -1,7 +1,7 @@
 """Tests for the remove module."""
 from unittest.mock import MagicMock, call, patch
 
-from sqlsynthgen.remove import remove_db_data
+from sqlsynthgen.remove import remove_db_data, remove_db_vocab
 from sqlsynthgen.settings import Settings
 from tests.examples import example_orm, remove_ssg
 from tests.utils import SSGTestCase, get_test_settings
@@ -20,7 +20,7 @@ class RemoveTestCase(SSGTestCase):
         remove_db_data(example_orm, remove_ssg)
         mock_delete.assert_has_calls(
             [
-                call(example_orm.Base.metadata.tables["myschema." + t])
+                call(example_orm.Base.metadata.tables[t])
                 for t in ("hospital_visit", "test_entity", "person", "entity")
             ]
         )
@@ -30,18 +30,38 @@ class RemoveTestCase(SSGTestCase):
 
     @patch("sqlsynthgen.remove.get_settings")
     def test_remove_db_data_raises(self, mock_get: MagicMock) -> None:
-        """Test the remove_db_data function."""
-        mock_get.return_value = Settings(_env_file=None)
+        """Check that remove_db_data raises if dst DSN is missing."""
+        mock_get.return_value = Settings(dst_user_name=None, _env_file=None)
         with self.assertRaises(AssertionError) as context_manager:
             remove_db_data(example_orm, remove_ssg)
         self.assertEqual(
             context_manager.exception.args[0], "Missing destination database settings"
         )
 
-    def test_remove_db_vocab(self) -> None:
+    @patch("sqlsynthgen.remove.get_settings", side_effect=get_test_settings)
+    @patch("sqlsynthgen.remove.create_db_engine")
+    @patch("sqlsynthgen.remove.delete", side_effect=(9,))
+    def test_remove_db_vocab(
+        self, mock_delete: MagicMock, mock_engine: MagicMock, _: MagicMock
+    ) -> None:
         """Test the remove_db_vocab function."""
-        # ToDo
-        # remove_db_vocab()
+        remove_db_vocab(example_orm, remove_ssg)
+        mock_delete.assert_has_calls(
+            [call(example_orm.Base.metadata.tables[t]) for t in ("concept",)]
+        )
+        dst_engine = mock_engine.return_value
+        dst_conn = dst_engine.connect.return_value.__enter__.return_value
+        dst_conn.execute.assert_has_calls([call(x) for x in (9,)])
+
+    @patch("sqlsynthgen.remove.get_settings")
+    def test_remove_db_vocab_raises(self, mock_get: MagicMock) -> None:
+        """Check that remove_db_vocab raises if dst DSN is missing."""
+        mock_get.return_value = Settings(dst_user_name=None, _env_file=None)
+        with self.assertRaises(AssertionError) as context_manager:
+            remove_db_vocab(example_orm, remove_ssg)
+        self.assertEqual(
+            context_manager.exception.args[0], "Missing destination database settings"
+        )
 
     def test_remove_tables(self) -> None:
         """Test the remove_db_tables function."""

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -2,17 +2,19 @@
 from unittest.mock import MagicMock, call, patch
 
 from sqlsynthgen.remove import remove_db_data
+from sqlsynthgen.settings import Settings
 from tests.examples import example_orm, remove_ssg
-from tests.utils import SSGTestCase
+from tests.utils import SSGTestCase, get_test_settings
 
 
 class RemoveTestCase(SSGTestCase):
     """Tests for removing data, vocabs and tables."""
 
+    @patch("sqlsynthgen.remove.get_settings", side_effect=get_test_settings)
     @patch("sqlsynthgen.remove.create_db_engine")
     @patch("sqlsynthgen.remove.delete", side_effect=(9, 8, 7, 6))
     def test_remove_db_data(
-        self, mock_delete: MagicMock, mock_engine: MagicMock
+        self, mock_delete: MagicMock, mock_engine: MagicMock, _: MagicMock
     ) -> None:
         """Test the remove_db_data function."""
         remove_db_data(example_orm, remove_ssg)
@@ -26,9 +28,20 @@ class RemoveTestCase(SSGTestCase):
         dst_conn = dst_engine.connect.return_value.__enter__.return_value
         dst_conn.execute.assert_has_calls([call(x) for x in (9, 8, 7, 6)])
 
+    @patch("sqlsynthgen.remove.get_settings")
+    def test_remove_db_data_raises(self, mock_get: MagicMock) -> None:
+        """Test the remove_db_data function."""
+        mock_get.return_value = Settings(_env_file=None)
+        with self.assertRaises(AssertionError) as context_manager:
+            remove_db_data(example_orm, remove_ssg)
+        self.assertEqual(
+            context_manager.exception.args[0], "Missing destination database settings"
+        )
+
     def test_remove_db_vocab(self) -> None:
         """Test the remove_db_vocab function."""
         # ToDo
+        # remove_db_vocab()
 
     def test_remove_tables(self) -> None:
         """Test the remove_db_tables function."""


### PR DESCRIPTION
Adds `remove-data`, `remove-vocab` and `remove-tables` commands, which should be almost the exact opposite of their `create-` counterparts.

Closes #85 