### PR TITLE
Add URLs and more detail to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 
 [project.urls]
 homepage = "https://github.com/alan-turing-institute/sqlsynthgen"
-documentation = "https://sqlsynthgen.readthedocs.io/"
+documentation = "https://sqlsynthgen.readthedocs.io/en/stable/"
 
 [tool.poetry.dependencies]
 python = "^3.9,<3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,21 @@
 [tool.poetry]
 name = "sqlsynthgen"
 version = "0.3.0"
-description = ""
+description = "Synthetic SQL data generator"
 authors = ["Iain <25081046+Iain-S@users.noreply.github.com>"]
 license = "MIT"
 readme = "README.md"
+classifiers = [
+    "Environment :: Console",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Database",
+    "Topic :: Utilities",
+]
+
+[project.urls]
+homepage = "https://github.com/alan-turing-institute/sqlsynthgen"
+documentation = "https://sqlsynthgen.readthedocs.io/"
 
 [tool.poetry.dependencies]
 python = "^3.9,<3.11"


### PR DESCRIPTION
I noticed that we don't have a `homepage` link from the [PyPi page](https://pypi.org/project/sqlsynthgen/). We may as well add some other details whilst we're at it.