### PR TITLE
Try different homepage and docs URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sqlsynthgen"
-version = "0.3.1"
+version = "0.3.2"
 description = "Synthetic SQL data generator"
 authors = ["Iain <25081046+Iain-S@users.noreply.github.com>"]
 license = "MIT"
@@ -12,8 +12,6 @@ classifiers = [
     "Topic :: Database",
     "Topic :: Utilities",
 ]
-
-[project.urls]
 homepage = "https://github.com/alan-turing-institute/sqlsynthgen"
 documentation = "https://sqlsynthgen.readthedocs.io/en/stable/"
 


### PR DESCRIPTION
At the moment, https://pypi.org/project/sqlsynthgen/ isn't showing the homepage or docs URLs for some reason (see, for contrast, the numpy page).