### PR TITLE
make-stats to return dictionaries

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -11,7 +11,7 @@ Which DBMSs does SqlSynthGen support?
 *************************************
 
 * SqlSynthGen most fully supports **PostgresSQL**, which it uses for its end-to-end functional tests.
-* SqlSynthGen also supports **MariaDB** with one exception: you cannot use source statistics (i.e. the ``make-stats`` command).
+* SqlSynthGen also supports **MariaDB**, as long as you don't set ``use-asyncio: true`` in your config.
 * SqlSynthGen *might*, work with **SQLite** but this is largely untested.
 
 Please open a GitHub issue if you would like to see support for another DBMS.

--- a/sqlsynthgen/make.py
+++ b/sqlsynthgen/make.py
@@ -517,5 +517,8 @@ async def make_src_stats(
         query_block["name"]: result
         for query_block, result in zip(query_blocks, results)
     }
-    # TODO Add a warning if the result of some query is empty.
+
+    for name, result in src_stats.items():
+        if not result:
+            logging.warning("src-stats query %s returned no results", name)
     return src_stats

--- a/sqlsynthgen/make.py
+++ b/sqlsynthgen/make.py
@@ -499,12 +499,13 @@ async def make_src_stats(
             private_result = reader.execute(dp_query)
             header = private_result[0]
             final_result = [
-                {header[i]: row[i] for i in range(len(row))}
+                {str(header[i]): row[i] for i in range(len(row))}
                 for row in private_result[1:]
             ]
         else:
             final_result = [
-                dict(row.items()) for row in raw_result.mappings().fetchall()
+                {str(k): v for k, v in row.items()}
+                for row in raw_result.mappings().fetchall()
             ]
         return final_result
 
@@ -516,4 +517,5 @@ async def make_src_stats(
         query_block["name"]: result
         for query_block, result in zip(query_blocks, results)
     }
+    # TODO Add a warning if the result of some query is empty.
     return src_stats

--- a/sqlsynthgen/make.py
+++ b/sqlsynthgen/make.py
@@ -497,11 +497,8 @@ async def make_src_stats(
             )
             reader = snsql.from_df(result_df, privacy=privacy, metadata=snsql_metadata)
             private_result = reader.execute(dp_query)
-            header = private_result[0]
-            final_result = [
-                {str(header[i]): row[i] for i in range(len(row))}
-                for row in private_result[1:]
-            ]
+            header = tuple(str(x) for x in private_result[0])
+            final_result = [dict(zip(header, row)) for row in private_result[1:]]
         else:
             final_result = [
                 {str(k): v for k, v in row.items()}

--- a/tests/examples/example_config.yaml
+++ b/tests/examples/example_config.yaml
@@ -49,10 +49,10 @@ tables:
           - 2022
           - 2022
         columns_assigned: stored_from
-      - name: row_generators.boolean_from_src_stats_generator
+      - name: row_generators.opt_out
         kwargs:
           generic: generic
-          src_stats: SRC_STATS["count_opt_outs"]
+          count_opt_outs: SRC_STATS["count_opt_outs"]
         columns_assigned: research_opt_out
 
   hospital_visit:

--- a/tests/examples/expected_ssg.py
+++ b/tests/examples/expected_ssg.py
@@ -60,8 +60,8 @@ class personGenerator:
         result = {}
         result["name"] = generic.person.full_name()
         result["stored_from"] = generic.datetime.datetime(2022, 2022)
-        result["research_opt_out"] = row_generators.boolean_from_src_stats_generator(
-            generic=generic, src_stats=SRC_STATS["count_opt_outs"]
+        result["research_opt_out"] = row_generators.opt_out(
+            generic=generic, count_opt_outs=SRC_STATS["count_opt_outs"]
         )
         result["nhs_number"] = self.unique_nhs_number_uniq(
             dst_db_conn, ["nhs_number"], generic.text.color

--- a/tests/examples/row_generators.py
+++ b/tests/examples/row_generators.py
@@ -16,9 +16,13 @@ def timespan_generator(
     return start, end, delta.total_seconds()
 
 
-def boolean_from_src_stats_generator(generic, src_stats):
-    num_false = int(next(x for x, y in src_stats if y is False))
-    num_true = int(next(x for x, y in src_stats if y is True))
+def opt_out(generic, count_opt_outs):
+    num_false = int(
+        next(row["num"] for row in count_opt_outs if row["research_opt_out"] is False)
+    )
+    num_true = int(
+        next(row["num"] for row in count_opt_outs if row["research_opt_out"] is True)
+    )
     return generic.weighted_boolean_provider.bool(num_true / num_false)
 
 

--- a/tests/examples/story_generators.py
+++ b/tests/examples/story_generators.py
@@ -31,8 +31,12 @@ def long_story(
     dst_db_conn: Any, generic: Any, count_opt_outs: list
 ) -> Generator[Tuple[str, Dict[str, Any]], Dict[str, Any], None]:
     # Find out whether this person opts out
-    count_false = next(s[0] for s in count_opt_outs if s[1] is False)
-    count_true = next(s[0] for s in count_opt_outs if s[1] is True)
+    count_false = int(
+        next(row["num"] for row in count_opt_outs if row["research_opt_out"] is False)
+    )
+    count_true = int(
+        next(row["num"] for row in count_opt_outs if row["research_opt_out"] is True)
+    )
     opt_out_rate = count_true / (count_true + count_false)
     opt_out = generic.weighted_boolean_provider.bool(opt_out_rate)
 

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -276,15 +276,22 @@ class TestMakeStats(RequiresDBTestCase):
         )
         count_opt_outs = src_stats["count_opt_outs"]
         self.assertEqual(len(count_opt_outs), 2)
-        self.assertIsInstance(count_opt_outs[0][0], int)
-        self.assertIs(count_opt_outs[0][1], False)
-        self.assertIsInstance(count_opt_outs[1][0], int)
-        self.assertIs(count_opt_outs[1][1], True)
+        self.assertIsInstance(count_opt_outs[0]["num"], int)
+        self.assertIs(count_opt_outs[0]["research_opt_out"], False)
+        self.assertIsInstance(count_opt_outs[1]["num"], int)
+        self.assertIs(count_opt_outs[1]["research_opt_out"], True)
 
         count_names = src_stats["count_names"]
         self.assertEqual(len(count_names), 1)
-        self.assertEqual(count_names[0][0], 1000)
-        self.assertEqual(count_names[0][1], "Randy Random")
+        self.assertEqual(count_names[0]["num"], 1000)
+        self.assertEqual(count_names[0]["name"], "Randy Random")
+
+        avg_person_id = src_stats["avg_person_id"]
+        self.assertEqual(len(avg_person_id), 1)
+        self.assertEqual(avg_person_id[0]["avg_id"], 500.5)
+
+        # Check that dumping into YAML goes fine.
+        yaml.dump(src_stats)
 
     def test_make_stats_no_asyncio_schema(self) -> None:
         """Test that make_src_stats works when explicitly naming a schema."""


### PR DESCRIPTION
Makes for much nicer generators and human readable `src-stats.yaml`. Heavily backwards incompatible though.

Also logs a warning if any query returns no results, which can easily happen with `dp-queries` when using `censor_dims`.