### PR TITLE
Finance tutorial

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -36,5 +36,3 @@ python:
   install:
     - method: pip
       path: .
-      extra_requirements:
-        - docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # How to Develop for SQLSYNTHGEN
 
-The following instructions has been tested on MacOS Ventura, but they *should* work on other Unix-based OS.
+The following instructions have been tested on MacOS Ventura, but they *should* work on other Unix-based OS.
 
 ## Pre-requisites
 
@@ -34,7 +34,7 @@ Please install the following software on your workstation:
     poetry install --all-extras
     ```
 
-    *If you don't need to [build the project documentation](#building-documentation-locally), run instead just `poetry install`.*
+    *If you don't need to [build the project documentation](#building-documentation-locally), the `--all-extras` option can be omitted.*
 
 1. Install the git hook scripts. They will run whenever you perform a commit:
 
@@ -52,7 +52,7 @@ Please install the following software on your workstation:
 
 ## Running unit tests
 
-Executing unit tests is straightward:
+Executing unit tests is straightforward:
 
 ```bash
 cd sqlsynthgen

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Please install the following software on your workstation:
 
 1. [Poetry](https://python-poetry.org/docs/#installation).
 1. [Pre-commit](https://pre-commit.com/#install).
-1. [PosgreSQL](https://postgresapp.com).
+1. [PostgreSQL](https://postgresapp.com).
 
 ## Setting up your development environment
 

--- a/docs/source/tutorials/airbnb.rst
+++ b/docs/source/tutorials/airbnb.rst
@@ -297,6 +297,8 @@ The ``sessions.action`` column can have plausible actions rather than random str
 
 Still there are no privacy implications, but data can be generated that e.g. passes various filters and ``WHERE`` clauses that one might realistically run on the data, opening new utility, especially in testing.
 
+.. _source_statistics:
+
 Using aggregate statistics from the source data
 -----------------------------------------------
 

--- a/sqlsynthgen/base.py
+++ b/sqlsynthgen/base.py
@@ -23,7 +23,7 @@ class FileUploader:
             return
         try:
             with yaml_file.open("r", newline="", encoding="utf-8") as yamlfile:
-                rows = yaml.safe_load(yamlfile)
+                rows = yaml.load(yamlfile, Loader=yaml.Loader)
         except yaml.YAMLError as e:
             logging.warning("Error reading YAML file %s: %s", yaml_file, e)
             return

--- a/sqlsynthgen/main.py
+++ b/sqlsynthgen/main.py
@@ -99,7 +99,7 @@ def create_vocab(
     ssg_file: str = Option(SSG_FILENAME),
     verbose: bool = Option(False, "--verbose", "-v"),
 ) -> None:
-    """Create tables using the SQLAlchemy file.
+    """Import vocabulary data.
 
     Example:
         $ sqlsynthgen create-vocab
@@ -122,7 +122,7 @@ def create_tables(
     orm_file: str = Option(ORM_FILENAME),
     verbose: bool = Option(False, "--verbose", "-v"),
 ) -> None:
-    """Create schema from Python classes.
+    """Create schema from a SQLAlchemy ORM file.
 
     This CLI command creates the destination schema using object
     relational model declared as Python tables.

--- a/tests/examples/loans/config1.yaml
+++ b/tests/examples/loans/config1.yaml
@@ -2,8 +2,7 @@
 tables:
   tkeys:
     row_generators:
-      - name: generic.numeric.integer_number
+      - name: generic.random.choice
         columns_assigned: goodClient
         args:
-          - 0
-          - 127
+          - [0, 1]

--- a/tests/examples/loans/config2.yaml
+++ b/tests/examples/loans/config2.yaml
@@ -1,0 +1,10 @@
+---
+tables:
+  tkeys:
+    row_generators:
+      - name: generic.random.choice
+        columns_assigned: goodClient
+        args:
+          - [0, 1]
+  districts:
+    vocabulary_table: true

--- a/tests/examples/loans/config3.yaml
+++ b/tests/examples/loans/config3.yaml
@@ -1,0 +1,36 @@
+---
+tables:
+  tkeys:
+    row_generators:
+      - name: generic.random.choice
+        columns_assigned: goodClient
+        args:
+          - [0, 1]
+  districts:
+    vocabulary_table: true
+src-stats:
+  - name: count_cards_type
+    query: >
+       SELECT
+         c.type AS card_type,
+         d.client_id
+       FROM cards c
+       JOIN disps d
+         on c.disp_id = d.id
+    dp-query: >
+      SELECT
+        count(*),
+        card_type
+      FROM query_result
+      GROUP BY card_type
+    epsilon: 0.1
+    delta: 0.0001
+    snsql-metadata:
+      client_id:
+        name: client_id
+        type: int
+        private_id: True
+      card_type:
+        name: card_type
+        type: string
+        private_id: False

--- a/tests/examples/loans/config3.yaml
+++ b/tests/examples/loans/config3.yaml
@@ -1,25 +1,16 @@
 ---
-tables:
-  tkeys:
-    row_generators:
-      - name: generic.random.choice
-        columns_assigned: goodClient
-        args:
-          - [0, 1]
-  districts:
-    vocabulary_table: true
 src-stats:
-  - name: count_cards_type
+  - name: count_card_types
     query: >
-       SELECT
-         c.type AS card_type,
-         d.client_id
-       FROM cards c
-       JOIN disps d
-         on c.disp_id = d.id
+      SELECT
+        c.type AS card_type,
+        d.client_id
+      FROM cards c
+      JOIN disps d
+        on c.disp_id = d.id
     dp-query: >
       SELECT
-        count(*),
+        count(*) AS the_count,
         card_type
       FROM query_result
       GROUP BY card_type
@@ -34,3 +25,19 @@ src-stats:
         name: card_type
         type: string
         private_id: False
+row_generators_module: my_row_generators
+tables:
+  cards:
+    row_generators:
+      - name: my_row_generators.my_card_func
+        kwargs:
+          stats: SRC_STATS["count_card_types"]
+        columns_assigned: type
+  tkeys:
+    row_generators:
+      - name: generic.random.choice
+        columns_assigned: goodClient
+        args:
+          - [0, 1]
+  districts:
+    vocabulary_table: true

--- a/tests/examples/loans/my_row_generators.py
+++ b/tests/examples/loans/my_row_generators.py
@@ -1,0 +1,9 @@
+import random
+
+def my_card_func(stats):
+    """Choose a weighted card type."""
+    total = sum([x["the_count"] for x in stats])
+    return random.choices(
+        population = tuple(x["card_type"] for x in stats),
+        weights = tuple(x["the_count"] / total for x in stats)
+    )[0]

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -27,6 +27,7 @@ class RstTests(TestCase):
             'No directive entry for "literalinclude"',
             'Hyperlink target "enduser" is not referenced',
             'Hyperlink target "introduction" is not referenced',
+            'Hyperlink target "source-statistics" is not referenced',
         ]
         filtered_errors = []
         for file_errors in all_errors:


### PR DESCRIPTION
## Summary

Finishes the loans dataset tutorial.

I have not used story generators but have covered the other features (including the fact that we now have a SNS workaround for MariaDB).

## Other Changes

### 1

Removes reference in readthedocs config to `docs/requirements.txt`, which no longer exists.

### 2

Uses `yaml.load()` rather than `yaml.safe_load()` as we are not using the safe dumper in `download_table()`. The alternative would be to use the safe version in both. The "unsafe" version gives us vocab export files that can look a bit like this, with the data type included when its literal value is not enough to fully define it:

```yaml
- A10: !!python/object/apply:decimal.Decimal
  - '100'
  A11: 12541

```
