### PR TITLE
Warn whenever an invalid config is loaded

### DIFF
--- a/sqlsynthgen/main.py
+++ b/sqlsynthgen/main.py
@@ -15,7 +15,7 @@ from sqlsynthgen.create import create_db_data, create_db_tables, create_db_vocab
 from sqlsynthgen.make import make_src_stats, make_table_generators, make_tables_file
 from sqlsynthgen.remove import remove_db_data, remove_db_tables, remove_db_vocab
 from sqlsynthgen.settings import Settings, get_settings
-from sqlsynthgen.utils import CONFIG_SCHEMA_PATH, import_file, read_yaml_file
+from sqlsynthgen.utils import CONFIG_SCHEMA_PATH, import_file, read_config_file
 
 # pylint: disable=too-many-arguments
 
@@ -178,7 +178,7 @@ def make_generators(
     _require_src_db_dsn(settings)
 
     orm_module: ModuleType = import_file(orm_file)
-    generator_config = read_yaml_file(config_file) if config_file is not None else {}
+    generator_config = read_config_file(config_file) if config_file is not None else {}
     result: str = make_table_generators(
         orm_module, generator_config, stats_file, overwrite_files=force
     )
@@ -210,7 +210,7 @@ def make_stats(
     if not force:
         _check_file_non_existence(stats_file_path)
 
-    config = read_yaml_file(config_file) if config_file is not None else {}
+    config = read_config_file(config_file) if config_file is not None else {}
 
     settings = get_settings()
     src_dsn: str = _require_src_db_dsn(settings)

--- a/sqlsynthgen/main.py
+++ b/sqlsynthgen/main.py
@@ -15,16 +15,13 @@ from sqlsynthgen.create import create_db_data, create_db_tables, create_db_vocab
 from sqlsynthgen.make import make_src_stats, make_table_generators, make_tables_file
 from sqlsynthgen.remove import remove_db_data, remove_db_tables, remove_db_vocab
 from sqlsynthgen.settings import Settings, get_settings
-from sqlsynthgen.utils import import_file, read_yaml_file
+from sqlsynthgen.utils import CONFIG_SCHEMA_PATH, import_file, read_yaml_file
 
 # pylint: disable=too-many-arguments
 
 ORM_FILENAME: Final[str] = "orm.py"
 SSG_FILENAME: Final[str] = "ssg.py"
 STATS_FILENAME: Final[str] = "src-stats.yaml"
-CONFIG_SCHEMA_PATH: Final[Path] = (
-    Path(__file__).parent / "json_schemas/config_schema.json"
-)
 
 app = Typer(no_args_is_help=True)
 

--- a/sqlsynthgen/utils.py
+++ b/sqlsynthgen/utils.py
@@ -19,11 +19,12 @@ CONFIG_SCHEMA_PATH: Final[Path] = (
 )
 
 
-def read_config_file(path: str) -> dict:
+def read_config_file(path: str, verbose: bool = False) -> dict:
     """Read a config file, warning if it is invalid.
 
     Args:
         path: The path to a YAML-format config file.
+        verbose: Whether to print detailed or short warnings.
 
     Returns:
         The config file as a dictionary.
@@ -37,7 +38,10 @@ def read_config_file(path: str) -> dict:
     try:
         validate(config, schema_config)
     except ValidationError as e:
-        logging.warning("The config file is invalid:\n%s", e)
+        if verbose:
+            logging.warning(
+                "The config file is invalid:\n%s", e.message if verbose else e
+            )
 
     return config
 

--- a/sqlsynthgen/utils.py
+++ b/sqlsynthgen/utils.py
@@ -1,6 +1,5 @@
 """Utility functions."""
 import json
-import logging
 import os
 import sys
 from importlib import import_module
@@ -19,12 +18,11 @@ CONFIG_SCHEMA_PATH: Final[Path] = (
 )
 
 
-def read_config_file(path: str, verbose: bool = False) -> dict:
+def read_config_file(path: str) -> dict:
     """Read a config file, warning if it is invalid.
 
     Args:
         path: The path to a YAML-format config file.
-        verbose: Whether to print detailed or short warnings.
 
     Returns:
         The config file as a dictionary.
@@ -38,10 +36,7 @@ def read_config_file(path: str, verbose: bool = False) -> dict:
     try:
         validate(config, schema_config)
     except ValidationError as e:
-        if verbose:
-            logging.warning(
-                "The config file is invalid:\n%s", e.message if verbose else e
-            )
+        print("The config file is invalid:", e.message)
 
     return config
 

--- a/sqlsynthgen/utils.py
+++ b/sqlsynthgen/utils.py
@@ -19,10 +19,19 @@ CONFIG_SCHEMA_PATH: Final[Path] = (
 )
 
 
-def read_yaml_file(path: str) -> Any:
-    """Read a yaml file in to dictionary, given a path."""
+def read_config_file(path: str) -> dict:
+    """Read a config file, warning if it is invalid.
+
+    Args:
+        path: The path to a YAML-format config file.
+
+    Returns:
+        The config file as a dictionary.
+    """
     with open(path, "r", encoding="utf8") as f:
         config = yaml.safe_load(f)
+
+    assert isinstance(config, dict)
 
     schema_config = json.loads(CONFIG_SCHEMA_PATH.read_text(encoding="UTF-8"))
     try:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,12 @@ from pydantic.tools import parse_obj_as
 from sqlalchemy import Column, Integer, create_engine, insert
 from sqlalchemy.orm import declarative_base
 
-from sqlsynthgen.utils import create_db_engine, download_table, import_file
+from sqlsynthgen.utils import (
+    create_db_engine,
+    download_table,
+    import_file,
+    read_yaml_file,
+)
 from tests.utils import RequiresDBTestCase, SSGTestCase, run_psql
 
 # pylint: disable=invalid-name
@@ -115,3 +120,14 @@ class TestCreateDBEngine(RequiresDBTestCase):
 
         # With schema
         create_db_engine(self.dsn, schema_name="public", use_asyncio=True)
+
+
+class TestReadYaml(SSGTestCase):
+    """Tests for the read_yaml_file function."""
+
+    def test_warns_of_invalid_config(self) -> None:
+        """Test that we get a warning if the config is invalid."""
+        with self.assertLogs(level="WARNING") as log:
+            read_yaml_file("tests/examples/invalid_config.yaml")
+
+        self.assertIn("The config file is invalid:", log.output[0])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,7 @@ from sqlsynthgen.utils import (
     create_db_engine,
     download_table,
     import_file,
-    read_yaml_file,
+    read_config_file,
 )
 from tests.utils import RequiresDBTestCase, SSGTestCase, run_psql
 
@@ -122,12 +122,12 @@ class TestCreateDBEngine(RequiresDBTestCase):
         create_db_engine(self.dsn, schema_name="public", use_asyncio=True)
 
 
-class TestReadYaml(SSGTestCase):
-    """Tests for the read_yaml_file function."""
+class TestReadConfig(SSGTestCase):
+    """Tests for the read_config_file function."""
 
     def test_warns_of_invalid_config(self) -> None:
         """Test that we get a warning if the config is invalid."""
         with self.assertLogs(level="WARNING") as log:
-            read_yaml_file("tests/examples/invalid_config.yaml")
+            read_config_file("tests/examples/invalid_config.yaml")
 
         self.assertIn("The config file is invalid:", log.output[0])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,9 @@
 """Tests for the utils module."""
 import os
 import sys
+from io import StringIO
 from pathlib import Path
+from unittest.mock import patch
 
 from pydantic import PostgresDsn
 from pydantic.tools import parse_obj_as
@@ -127,7 +129,7 @@ class TestReadConfig(SSGTestCase):
 
     def test_warns_of_invalid_config(self) -> None:
         """Test that we get a warning if the config is invalid."""
-        with self.assertLogs(level="WARNING") as log:
+        with patch("sys.stdout", new=StringIO()) as mock_stdout:
             read_config_file("tests/examples/invalid_config.yaml")
 
-        self.assertIn("The config file is invalid:", log.output[0])
+        self.assertIn("The config file is invalid:", mock_stdout.getvalue())


### PR DESCRIPTION
### Summary

At the moment, you need to manually validate the config but we should probably warn you whenever an invalid config is detected.

### Questions for reviewers

- Should we always warn or only if `--verbose` is requested?
- Is the error we print too verbose? If so, we could print only the first line of the message instead.

> WARNING:root:The config file is invalid:
{'a': 'b'} is not of type 'array'
_
Failed validating 'type' in schema['properties']['tables']['patternProperties']['.*']['properties']['row_generators']['items']['properties']['args']:
    {'type': 'array'}
_
On instance['tables']['tkeys']['row_generators'][0]['args']:
    {'a': 'b'}
