### PR TITLE
Sqla2 type hints iain

### DIFF
--- a/sqlsynthgen/create.py
+++ b/sqlsynthgen/create.py
@@ -1,6 +1,6 @@
 """Functions and classes to create and populate the target database."""
 import logging
-from typing import Any, Dict, Generator, List, Tuple
+from typing import Any, Generator, Tuple
 
 from sqlalchemy import Connection, insert
 from sqlalchemy.exc import IntegrityError
@@ -10,7 +10,7 @@ from sqlsynthgen.base import FileUploader, TableGenerator
 from sqlsynthgen.settings import get_settings
 from sqlsynthgen.utils import create_db_engine, get_sync_engine
 
-Story = Generator[Tuple[str, Dict[str, Any]], Dict[str, Any], None]
+Story = Generator[Tuple[str, dict[str, Any]], dict[str, Any], None]
 
 
 def create_db_tables(metadata: MetaData) -> None:
@@ -34,7 +34,7 @@ def create_db_tables(metadata: MetaData) -> None:
     metadata.create_all(engine)
 
 
-def create_db_vocab(vocab_dict: Dict[str, FileUploader]) -> None:
+def create_db_vocab(vocab_dict: dict[str, FileUploader]) -> None:
     """Load vocabulary tables from files."""
     settings = get_settings()
     dst_dsn: str = settings.dst_dsn or ""
@@ -81,8 +81,8 @@ def create_db_data(
 
 def _populate_story(
     story: Story,
-    table_dict: Dict[str, Table],
-    table_generator_dict: Dict[str, TableGenerator],
+    table_dict: dict[str, Table],
+    table_generator_dict: dict[str, TableGenerator],
     dst_conn: Connection,
 ) -> None:
     """Write to the database all the rows created by the given story."""
@@ -131,7 +131,7 @@ def populate(
     # Each story generator returns a python generator (an unfortunate naming clash with
     # what we call generators). Iterating over it yields individual rows for the
     # database. First, collect all of the python generators into a single list.
-    stories: List[Story] = sum(
+    stories: list[Story] = sum(
         [
             [sg["name"](dst_conn) for _ in range(sg["num_stories_per_pass"])]
             for sg in story_generator_list

--- a/sqlsynthgen/create.py
+++ b/sqlsynthgen/create.py
@@ -1,6 +1,6 @@
 """Functions and classes to create and populate the target database."""
 import logging
-from typing import Any, Generator, Tuple
+from typing import Any, Generator, Mapping, Sequence, Tuple
 
 from sqlalchemy import Connection, insert
 from sqlalchemy.exc import IntegrityError
@@ -34,7 +34,7 @@ def create_db_tables(metadata: MetaData) -> None:
     metadata.create_all(engine)
 
 
-def create_db_vocab(vocab_dict: dict[str, FileUploader]) -> None:
+def create_db_vocab(vocab_dict: Mapping[str, FileUploader]) -> None:
     """Load vocabulary tables from files."""
     settings = get_settings()
     dst_dsn: str = settings.dst_dsn or ""
@@ -55,9 +55,9 @@ def create_db_vocab(vocab_dict: dict[str, FileUploader]) -> None:
 
 
 def create_db_data(
-    sorted_tables: list[Table],
-    table_generator_dict: dict[str, TableGenerator],
-    story_generator_list: list[dict[str, Any]],
+    sorted_tables: Sequence[Table],
+    table_generator_dict: Mapping[str, TableGenerator],
+    story_generator_list: Sequence[Mapping[str, Any]],
     num_passes: int,
 ) -> None:
     """Connect to a database and populate it with data."""
@@ -81,8 +81,8 @@ def create_db_data(
 
 def _populate_story(
     story: Story,
-    table_dict: dict[str, Table],
-    table_generator_dict: dict[str, TableGenerator],
+    table_dict: Mapping[str, Table],
+    table_generator_dict: Mapping[str, TableGenerator],
     dst_conn: Connection,
 ) -> None:
     """Write to the database all the rows created by the given story."""
@@ -121,9 +121,9 @@ def _populate_story(
 
 def populate(
     dst_conn: Connection,
-    tables: list[Table],
-    table_generator_dict: dict[str, TableGenerator],
-    story_generator_list: list[dict[str, Any]],
+    tables: Sequence[Table],
+    table_generator_dict: Mapping[str, TableGenerator],
+    story_generator_list: Sequence[Mapping[str, Any]],
 ) -> None:
     """Populate a database schema with synthetic data."""
     table_dict = {table.name: table for table in tables}

--- a/sqlsynthgen/create.py
+++ b/sqlsynthgen/create.py
@@ -16,8 +16,10 @@ Story = Generator[Tuple[str, Dict[str, Any]], Dict[str, Any], None]
 def create_db_tables(metadata: MetaData) -> None:
     """Create tables described by the sqlalchemy metadata object."""
     settings = get_settings()
+    dst_dsn: str = settings.dst_dsn or ""
+    assert dst_dsn != "", "Missing DST_DSN setting."
 
-    engine = get_sync_engine(create_db_engine(settings.dst_dsn))  # type: ignore
+    engine = get_sync_engine(create_db_engine(dst_dsn))
 
     # Create schema, if necessary.
     if settings.dst_schema:
@@ -27,9 +29,7 @@ def create_db_tables(metadata: MetaData) -> None:
                 connection.execute(CreateSchema(schema_name, if_not_exists=True))
 
         # Recreate the engine, this time with a schema specified
-        engine = get_sync_engine(
-            create_db_engine(settings.dst_dsn, schema_name=schema_name)  # type: ignore
-        )
+        engine = get_sync_engine(create_db_engine(dst_dsn, schema_name=schema_name))
 
     metadata.create_all(engine)
 
@@ -37,11 +37,11 @@ def create_db_tables(metadata: MetaData) -> None:
 def create_db_vocab(vocab_dict: Dict[str, FileUploader]) -> None:
     """Load vocabulary tables from files."""
     settings = get_settings()
+    dst_dsn: str = settings.dst_dsn or ""
+    assert dst_dsn != "", "Missing DST_DSN setting."
 
     dst_engine = get_sync_engine(
-        create_db_engine(
-            settings.dst_dsn, schema_name=settings.dst_schema  # type: ignore
-        )
+        create_db_engine(dst_dsn, schema_name=settings.dst_schema)
     )
 
     with dst_engine.connect() as dst_conn:
@@ -62,11 +62,11 @@ def create_db_data(
 ) -> None:
     """Connect to a database and populate it with data."""
     settings = get_settings()
+    dst_dsn: str = settings.dst_dsn or ""
+    assert dst_dsn != "", "Missing DST_DSN setting."
 
     dst_engine = get_sync_engine(
-        create_db_engine(
-            settings.dst_dsn, schema_name=settings.dst_schema  # type: ignore
-        )
+        create_db_engine(dst_dsn, schema_name=settings.dst_schema)
     )
 
     with dst_engine.connect() as dst_conn:

--- a/sqlsynthgen/make.py
+++ b/sqlsynthgen/make.py
@@ -359,11 +359,10 @@ def make_table_generators(
     story_generator_module_name = config.get("story_generators_module", None)
 
     settings = get_settings()
-    engine = get_sync_engine(
-        create_db_engine(
-            settings.src_dsn, schema_name=settings.src_schema  # type: ignore
-        )
-    )
+    src_dsn: str = settings.src_dsn or ""
+    assert src_dsn != "", "Missing SRC_DSN setting."
+
+    engine = get_sync_engine(create_db_engine(src_dsn, schema_name=settings.src_schema))
 
     tables: List[TableGeneratorInfo] = []
     vocabulary_tables: List[VocabularyTableGeneratorInfo] = []

--- a/sqlsynthgen/make.py
+++ b/sqlsynthgen/make.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from sys import stderr
 from types import ModuleType
-from typing import Any, Dict, Final, List, Optional, Tuple
+from typing import Any, Final, Optional, Tuple
 
 import pandas as pd
 import snsql
@@ -25,7 +25,7 @@ from sqlsynthgen import providers
 from sqlsynthgen.settings import get_settings
 from sqlsynthgen.utils import create_db_engine, download_table, get_sync_engine
 
-PROVIDER_IMPORTS: Final[List[str]] = []
+PROVIDER_IMPORTS: Final[list[str]] = []
 for entry_name, entry in inspect.getmembers(providers, inspect.isclass):
     if issubclass(entry, BaseProvider) and entry.__module__ == "sqlsynthgen.providers":
         PROVIDER_IMPORTS.append(entry_name)
@@ -49,14 +49,14 @@ class FunctionCall:
     """Contains the ssg.py content related function calls."""
 
     function_name: str
-    argument_values: List[str]
+    argument_values: list[str]
 
 
 @dataclass
 class RowGeneratorInfo:
     """Contains the ssg.py content related to row generators of a table."""
 
-    variable_names: List[str]
+    variable_names: list[str]
     function_call: FunctionCall
     primary_key: bool = False
 
@@ -68,8 +68,8 @@ class TableGeneratorInfo:
     class_name: str
     table_name: str
     rows_per_pass: int
-    row_gens: List[RowGeneratorInfo] = field(default_factory=list)
-    unique_constraints: List[UniqueConstraint] = field(default_factory=list)
+    row_gens: list[RowGeneratorInfo] = field(default_factory=list)
+    unique_constraints: list[UniqueConstraint] = field(default_factory=list)
 
 
 @dataclass
@@ -100,8 +100,8 @@ def _orm_class_from_table_name(
 
 def _get_function_call(
     function_name: str,
-    positional_arguments: Optional[List[Any]] = None,
-    keyword_arguments: Optional[Dict[str, Any]] = None,
+    positional_arguments: Optional[list[Any]] = None,
+    keyword_arguments: Optional[dict[str, Any]] = None,
 ) -> FunctionCall:
     if positional_arguments is None:
         positional_arguments = []
@@ -109,7 +109,7 @@ def _get_function_call(
     if keyword_arguments is None:
         keyword_arguments = {}
 
-    argument_values: List[str] = [str(value) for value in positional_arguments]
+    argument_values: list[str] = [str(value) for value in positional_arguments]
     argument_values += [f"{key}={value}" for key, value in keyword_arguments.items()]
 
     return FunctionCall(function_name=function_name, argument_values=argument_values)
@@ -117,21 +117,21 @@ def _get_function_call(
 
 def _get_row_generator(
     table_config: dict[str, Any],
-) -> tuple[List[RowGeneratorInfo], list[str]]:
+) -> tuple[list[RowGeneratorInfo], list[str]]:
     """Get the row generators information, for the given table."""
-    row_gen_info: List[RowGeneratorInfo] = []
-    config: List[Dict[str, Any]] = table_config.get("row_generators", {})
+    row_gen_info: list[RowGeneratorInfo] = []
+    config: list[dict[str, Any]] = table_config.get("row_generators", {})
     columns_covered = []
     for gen_conf in config:
         name: str = gen_conf["name"]
         columns_assigned = gen_conf["columns_assigned"]
-        keyword_arguments: Dict[str, Any] = gen_conf.get("kwargs", {})
-        positional_arguments: List[str] = gen_conf.get("args", [])
+        keyword_arguments: dict[str, Any] = gen_conf.get("kwargs", {})
+        positional_arguments: list[str] = gen_conf.get("args", [])
 
         if isinstance(columns_assigned, str):
             columns_assigned = [columns_assigned]
 
-        variable_names: List[str] = columns_assigned
+        variable_names: list[str] = columns_assigned
         try:
             columns_covered += columns_assigned
         except TypeError:
@@ -158,9 +158,9 @@ def _get_default_generator(
 
     # If it's a foreign key column, pull random values from the column it
     # references.
-    variable_names: List[str] = []
+    variable_names: list[str] = []
     generator_function: str = ""
-    generator_arguments: List[str] = []
+    generator_arguments: list[str] = []
 
     if column.foreign_keys:
         if len(column.foreign_keys) > 1:
@@ -202,7 +202,7 @@ def _get_default_generator(
     )
 
 
-def _get_provider_for_column(column: Column) -> Tuple[List[str], str, List[str]]:
+def _get_provider_for_column(column: Column) -> Tuple[list[str], str, list[str]]:
     """
     Get a default Mimesis provider and its arguments for a SQL column type.
 
@@ -210,11 +210,11 @@ def _get_provider_for_column(column: Column) -> Tuple[List[str], str, List[str]]
         column: SQLAlchemy column object
 
     Returns:
-        Tuple[str, str, List[str]]: Tuple containing the variable names to assign to,
+        Tuple[str, str, list[str]]: Tuple containing the variable names to assign to,
         generator function and any generator arguments.
     """
-    variable_names: List[str] = [column.name]
-    generator_arguments: List[str] = []
+    variable_names: list[str] = [column.name]
+    generator_arguments: list[str] = []
 
     column_type = type(column.type)
     column_size: Optional[int] = getattr(column.type, "length", None)
@@ -318,7 +318,7 @@ def _get_generator_for_table(
     return table_data
 
 
-def _get_story_generators(config: dict) -> List[StoryGeneratorInfo]:
+def _get_story_generators(config: dict) -> list[StoryGeneratorInfo]:
     """Get story generators."""
     generators = []
     for gen in config.get("story_generators", []):
@@ -364,8 +364,8 @@ def make_table_generators(
 
     engine = get_sync_engine(create_db_engine(src_dsn, schema_name=settings.src_schema))
 
-    tables: List[TableGeneratorInfo] = []
-    vocabulary_tables: List[VocabularyTableGeneratorInfo] = []
+    tables: list[TableGeneratorInfo] = []
+    vocabulary_tables: list[VocabularyTableGeneratorInfo] = []
 
     for table in tables_module.Base.metadata.sorted_tables:
         table_config = config.get("tables", {}).get(table.name, {})
@@ -397,7 +397,7 @@ def make_table_generators(
     )
 
 
-def generate_ssg_content(template_context: Dict[str, Any]) -> str:
+def generate_ssg_content(template_context: dict[str, Any]) -> str:
     """Generate the content of the ssg.py file as a string."""
     environment: Environment = Environment(
         loader=FileSystemLoader(TEMPLATE_DIRECTORY),
@@ -467,7 +467,7 @@ def make_tables_file(db_dsn: str, schema_name: Optional[str]) -> str:
 
 async def make_src_stats(
     dsn: str, config: dict, schema_name: Optional[str] = None
-) -> Dict[str, List[dict]]:
+) -> dict[str, list[dict]]:
     """Run the src-stats queries specified by the configuration.
 
     Query the src database with the queries in the src-stats block of the `config`
@@ -484,7 +484,7 @@ async def make_src_stats(
     use_asyncio = config.get("use-asyncio", False)
     engine = create_db_engine(dsn, schema_name=schema_name, use_asyncio=use_asyncio)
 
-    async def execute_query(query_block: Dict[str, Any]) -> Any:
+    async def execute_query(query_block: dict[str, Any]) -> Any:
         """Execute query in query_block."""
         query = text(query_block["query"])
         if isinstance(engine, AsyncEngine):

--- a/sqlsynthgen/make.py
+++ b/sqlsynthgen/make.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from sys import stderr
 from types import ModuleType
-from typing import Any, Final, Optional, Tuple
+from typing import Any, Final, Mapping, Optional, Sequence, Tuple
 
 import pandas as pd
 import snsql
@@ -100,8 +100,8 @@ def _orm_class_from_table_name(
 
 def _get_function_call(
     function_name: str,
-    positional_arguments: Optional[list[Any]] = None,
-    keyword_arguments: Optional[dict[str, Any]] = None,
+    positional_arguments: Optional[Sequence[Any]] = None,
+    keyword_arguments: Optional[Mapping[str, Any]] = None,
 ) -> FunctionCall:
     if positional_arguments is None:
         positional_arguments = []
@@ -116,7 +116,7 @@ def _get_function_call(
 
 
 def _get_row_generator(
-    table_config: dict[str, Any],
+    table_config: Mapping[str, Any],
 ) -> tuple[list[RowGeneratorInfo], list[str]]:
     """Get the row generators information, for the given table."""
     row_gen_info: list[RowGeneratorInfo] = []
@@ -125,8 +125,8 @@ def _get_row_generator(
     for gen_conf in config:
         name: str = gen_conf["name"]
         columns_assigned = gen_conf["columns_assigned"]
-        keyword_arguments: dict[str, Any] = gen_conf.get("kwargs", {})
-        positional_arguments: list[str] = gen_conf.get("args", [])
+        keyword_arguments: Mapping[str, Any] = gen_conf.get("kwargs", {})
+        positional_arguments: Sequence[str] = gen_conf.get("args", [])
 
         if isinstance(columns_assigned, str):
             columns_assigned = [columns_assigned]
@@ -291,7 +291,7 @@ def _enforce_unique_constraints(table_data: TableGeneratorInfo) -> None:
 
 
 def _get_generator_for_table(
-    tables_module: ModuleType, table_config: dict[str, Any], table: Table
+    tables_module: ModuleType, table_config: Mapping[str, Any], table: Table
 ) -> TableGeneratorInfo:
     """Get generator information for the given table."""
     unique_constraints = [
@@ -318,7 +318,7 @@ def _get_generator_for_table(
     return table_data
 
 
-def _get_story_generators(config: dict) -> list[StoryGeneratorInfo]:
+def _get_story_generators(config: Mapping) -> list[StoryGeneratorInfo]:
     """Get story generators."""
     generators = []
     for gen in config.get("story_generators", []):
@@ -339,7 +339,7 @@ def _get_story_generators(config: dict) -> list[StoryGeneratorInfo]:
 
 def make_table_generators(
     tables_module: ModuleType,
-    config: dict,
+    config: Mapping,
     src_stats_filename: Optional[str],
     overwrite_files: bool = False,
 ) -> str:
@@ -397,7 +397,7 @@ def make_table_generators(
     )
 
 
-def generate_ssg_content(template_context: dict[str, Any]) -> str:
+def generate_ssg_content(template_context: Mapping[str, Any]) -> str:
     """Generate the content of the ssg.py file as a string."""
     environment: Environment = Environment(
         loader=FileSystemLoader(TEMPLATE_DIRECTORY),
@@ -466,7 +466,7 @@ def make_tables_file(db_dsn: str, schema_name: Optional[str]) -> str:
 
 
 async def make_src_stats(
-    dsn: str, config: dict, schema_name: Optional[str] = None
+    dsn: str, config: Mapping, schema_name: Optional[str] = None
 ) -> dict[str, list[dict]]:
     """Run the src-stats queries specified by the configuration.
 
@@ -484,7 +484,7 @@ async def make_src_stats(
     use_asyncio = config.get("use-asyncio", False)
     engine = create_db_engine(dsn, schema_name=schema_name, use_asyncio=use_asyncio)
 
-    async def execute_query(query_block: dict[str, Any]) -> Any:
+    async def execute_query(query_block: Mapping[str, Any]) -> Any:
         """Execute query in query_block."""
         query = text(query_block["query"])
         if isinstance(engine, AsyncEngine):

--- a/sqlsynthgen/utils.py
+++ b/sqlsynthgen/utils.py
@@ -93,7 +93,7 @@ def create_db_engine(
     db_dsn: str,
     schema_name: Optional[str] = None,
     use_asyncio: bool = False,
-    **kwargs: dict,
+    **kwargs: Any,
 ) -> MaybeAsyncEngine:
     """Create a SQLAlchemy Engine."""
     if use_asyncio:

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -4,9 +4,11 @@ from pathlib import Path
 from typing import Any, Generator, Tuple
 from unittest.mock import MagicMock, call, patch
 
-from sqlalchemy import Column, Integer, create_engine
+from sqlalchemy import Column, Connection, Integer, create_engine
 from sqlalchemy.orm import declarative_base
+from sqlalchemy.schema import Table
 
+from sqlsynthgen.base import FileUploader, TableGenerator
 from sqlsynthgen.create import (
     Story,
     _populate_story,
@@ -69,17 +71,17 @@ class MyTestCase(SSGTestCase):
         for num_stories_per_pass, num_rows_per_pass in itt.product([0, 2], [0, 3]):
             with patch("sqlsynthgen.create.insert") as mock_insert:
                 mock_values = mock_insert.return_value.values
-                mock_dst_conn = MagicMock()
+                mock_dst_conn = MagicMock(spec=Connection)
                 mock_dst_conn.execute.return_value.returned_defaults = {}
-                mock_table = MagicMock()
+                mock_table = MagicMock(spec=Table)
                 mock_table.name = table_name
-                mock_gen = MagicMock()
+                mock_gen = MagicMock(spec=TableGenerator)
                 mock_gen.num_rows_per_pass = num_rows_per_pass
                 mock_gen.return_value = {}
 
-                tables = [mock_table]
-                row_generators = {table_name: mock_gen}
-                story_generators = (
+                tables: list[Table] = [mock_table]
+                row_generators: dict[str, TableGenerator] = {table_name: mock_gen}
+                story_generators: list[dict[str, Any]] = (
                     [
                         {
                             "name": mock_story_gen,
@@ -91,8 +93,8 @@ class MyTestCase(SSGTestCase):
                 )
                 populate(
                     mock_dst_conn,
-                    tables,  # type: ignore
-                    row_generators,  # type: ignore
+                    tables,
+                    row_generators,
                     story_generators,
                 )
 
@@ -117,19 +119,22 @@ class MyTestCase(SSGTestCase):
     @patch("sqlsynthgen.create.insert")
     def test_populate_diff_length(self, mock_insert: MagicMock) -> None:
         """Test when generators and tables differ in length."""
-        mock_dst_conn = MagicMock()
-        mock_gen_two = MagicMock()
-        mock_gen_three = MagicMock()
-        mock_table_one = MagicMock()
+        mock_dst_conn = MagicMock(spec=Connection)
+        mock_gen_two = MagicMock(spec_set=TableGenerator)
+        mock_gen_three = MagicMock(spec_set=TableGenerator)
+        mock_table_one = MagicMock(spec=Table)
         mock_table_one.name = "one"
-        mock_table_two = MagicMock()
+        mock_table_two = MagicMock(spec=Table)
         mock_table_two.name = "two"
-        mock_table_three = MagicMock()
+        mock_table_three = MagicMock(spec=Table)
         mock_table_three.name = "three"
-        tables = [mock_table_one, mock_table_two, mock_table_three]
-        row_generators = {"two": mock_gen_two, "three": mock_gen_three}
+        tables: list[Table] = [mock_table_one, mock_table_two, mock_table_three]
+        row_generators: dict[str, TableGenerator] = {
+            "two": mock_gen_two,
+            "three": mock_gen_three,
+        }
 
-        populate(mock_dst_conn, tables, row_generators, [])  # type: ignore
+        populate(mock_dst_conn, tables, row_generators, [])
         self.assertListEqual(
             [call(mock_table_two), call(mock_table_three)], mock_insert.call_args_list
         )
@@ -144,16 +149,22 @@ class MyTestCase(SSGTestCase):
     ) -> None:
         """Test the create_db_vocab function."""
         mock_get_settings.return_value = get_test_settings()
-        vocab_list = {"table_name": MagicMock()}
-        create_db_vocab(vocab_list)  # type: ignore
-        vocab_list["table_name"].load.assert_called_once_with(
+
+        mock_load = MagicMock()
+        mock_vocab = MagicMock(spec=FileUploader)
+        mock_vocab.load = mock_load
+        vocab_list: dict[str, FileUploader] = {"table_name": mock_vocab}
+
+        create_db_vocab(vocab_list)
+
+        mock_load.assert_called_once_with(
             mock_create_engine.return_value.connect.return_value.__enter__.return_value
         )
         mock_create_engine.assert_called_once_with(
             mock_get_settings.return_value.dst_dsn
         )
         # Running the same insert twice should be fine.
-        create_db_vocab(vocab_list)  # type: ignore
+        create_db_vocab(vocab_list)
 
 
 class TestStoryDefaults(RequiresDBTestCase):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,5 @@
 """Tests for the main module."""
 from pathlib import Path
-from typing import Dict
 from unittest.mock import MagicMock, call, patch
 
 import yaml
@@ -368,12 +367,12 @@ class TestCLI(SSGTestCase):
         """Tests that the make-stats command overwrite files when instructed."""
         test_config_file: str = "tests/examples/example_config.yaml"
         with open(test_config_file, "r", encoding="utf8") as f:
-            config_file_content: Dict = yaml.safe_load(f)
+            config_file_content: dict = yaml.safe_load(f)
 
         mock_path.return_value.exists.return_value = True
         test_settings: Settings = get_test_settings()
         mock_get_settings.return_value = test_settings
-        make_test_output: Dict = {"some_stat": 0}
+        make_test_output: dict = {"some_stat": 0}
         mock_make.return_value = make_test_output
 
         for force_option in ["--force", "-f"]:

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -3,7 +3,6 @@ import asyncio
 import os
 from io import StringIO
 from pathlib import Path
-from typing import Dict
 from unittest.mock import MagicMock, patch
 
 import yaml
@@ -83,7 +82,7 @@ class TestMakeGenerators(SSGTestCase):
         mock_get_settings.return_value = get_test_settings()
         configuration_file: str = "example_config.yaml"
         with open(configuration_file, "r", encoding="utf8") as f:
-            configuration: Dict = yaml.safe_load(f)
+            configuration: dict = yaml.safe_load(f)
         stats_path = "example_stats.yaml"
 
         try:
@@ -115,7 +114,7 @@ class TestMakeGenerators(SSGTestCase):
             expected: str = expected_output.read()
         conf_path = "example_config.yaml"
         with open(conf_path, "r", encoding="utf8") as f:
-            config: Dict = yaml.safe_load(f)
+            config: dict = yaml.safe_load(f)
         stats_path: str = "example_stats.yaml"
 
         actual: str = make_table_generators(


### PR DESCRIPTION
Changes

- Uses type hints and `MagicMock(spec=MockedClass)` feature to remove `# type: ignore` from tests. See https://stackoverflow.com/a/11283173/3324095
- Uses the abstract `Sequence` in place of `List` and `Mapping` in place of `Dict` in function parameters as this allows a wider range of types to be passed in. Keeps concrete types are still used for return types as they are more precise.
- Swaps `List` for `list` and `Dict` for `dict` as we require Python >= 3.9 and this feature was added in 3.9.