### PR TITLE
0.3.2 -> 0.3.3

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -40,13 +40,6 @@ jobs:
         shell: bash
         if: steps.poetry-cache.outputs.cache-hit != 'true'
         run: |
-          # workaround start
-          # this is a pyyaml v5 vs cython v3 conflict workaround
-          # see https://github.com/alan-turing-institute/sqlsynthgen/issues/120
-          python -m poetry run pip install "cython<3"
-          python -m poetry run pip install wheel
-          python -m poetry run pip install --no-build-isolation "pyyaml==5.4.1"
-          # workaround end
           python -m poetry install --all-extras
       - name: Install Pre-Commit
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,13 +46,6 @@ jobs:
         shell: bash
         if: steps.poetry-cache.outputs.cache-hit != 'true'
         run: |
-          # workaround start
-          # this is a pyyaml v5 vs cython v3 conflict workaround
-          # see https://github.com/alan-turing-institute/sqlsynthgen/issues/120
-          python -m poetry run pip install "cython<3"
-          python -m poetry run pip install wheel
-          python -m poetry run pip install --no-build-isolation "pyyaml==5.4.1"
-          # workaround end
           python -m poetry install --all-extras
       - name: Create src database
         shell: bash

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,13 +14,6 @@ build:
     # nodejs: "19"
     # rust: "1.64"
     # golang: "1.19"
-  jobs:
-    # This pre-install job is a pyyaml v5 vs cython v3 conflict workaround
-    # see https://github.com/alan-turing-institute/sqlsynthgen/issues/120
-    pre_install:
-      - pip install "cython<3"
-      - pip install wheel
-      - pip install --no-build-isolation "pyyaml==5.4.1"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -12,16 +12,6 @@ To use SqlSynthGen, first install it:
 
    $ pip install sqlsynthgen
 
-
-If Pip errors when installing PyYaml, you will need to manually specify the Cython version and manually install PyYaml (this is a temporary workaround for a PyYaml v5 conflict with Cython v3, see `here <https://github.com/yaml/pyyaml/issues/601>`_ for full details):
-
-.. code-block:: console
-
-    pip install "cython<3"
-    pip install wheel
-    pip install --no-build-isolation "pyyaml==5.4.1"
-    pip install sqlsynthgen
-
 Check that you can view the help message with:
 
 .. code-block:: console

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sqlsynthgen"
-version = "0.3.2"
+version = "0.3.3"
 description = "Synthetic SQL data generator"
 authors = ["Iain <25081046+Iain-S@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
- Bump the version number
- Remove the Cython workaround (not required as of the SQLAlchemy 2 upgrade)