### PR TITLE
Logging verbosity

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -87,7 +87,6 @@ disable=raw-checker-failed,
         deprecated-pragma,
         use-symbolic-message-instead,
         too-few-public-methods,
-        global-variable-not-assigned,
         duplicate-code
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/.pylintrc
+++ b/.pylintrc
@@ -87,6 +87,7 @@ disable=raw-checker-failed,
         deprecated-pragma,
         use-symbolic-message-instead,
         too-few-public-methods,
+        global-variable-not-assigned,
         duplicate-code
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/sqlsynthgen/base.py
+++ b/sqlsynthgen/base.py
@@ -1,5 +1,4 @@
 """Base table generator classes."""
-import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
@@ -9,6 +8,8 @@ import yaml
 from sqlalchemy import Connection, insert
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.schema import Table
+
+from sqlsynthgen.utils import logger
 
 
 class TableGenerator(ABC):
@@ -39,17 +40,17 @@ class FileUploader:
         """Load the data from file."""
         yaml_file = Path(self.table.fullname + ".yaml")
         if not yaml_file.exists():
-            logging.warning("File %s not found. Skipping...", yaml_file)
+            logger.warning("File %s not found. Skipping...", yaml_file)
             return
         try:
             with yaml_file.open("r", newline="", encoding="utf-8") as yamlfile:
                 rows = yaml.load(yamlfile, Loader=yaml.Loader)
         except yaml.YAMLError as e:
-            logging.warning("Error reading YAML file %s: %s", yaml_file, e)
+            logger.warning("Error reading YAML file %s: %s", yaml_file, e)
             return
 
         if not rows:
-            logging.warning("No rows in %s. Skipping...", yaml_file)
+            logger.warning("No rows in %s. Skipping...", yaml_file)
             return
 
         try:
@@ -57,6 +58,6 @@ class FileUploader:
             connection.execute(stmt)
             connection.commit()
         except SQLAlchemyError as e:
-            logging.warning(
+            logger.warning(
                 "Error inserting rows into table %s: %s", self.table.fullname, e
             )

--- a/sqlsynthgen/create.py
+++ b/sqlsynthgen/create.py
@@ -45,6 +45,7 @@ def create_db_vocab(vocab_dict: Mapping[str, FileUploader]) -> None:
 
     with dst_engine.connect() as dst_conn:
         for vocab_table in vocab_dict.values():
+            logger.debug("Loading vocabulary table %s", vocab_table.table.name)
             try:
                 vocab_table.load(dst_conn)
             except IntegrityError:

--- a/sqlsynthgen/create.py
+++ b/sqlsynthgen/create.py
@@ -1,5 +1,4 @@
 """Functions and classes to create and populate the target database."""
-import logging
 from typing import Any, Generator, Mapping, Sequence, Tuple
 
 from sqlalchemy import Connection, insert
@@ -8,7 +7,7 @@ from sqlalchemy.schema import CreateSchema, MetaData, Table
 
 from sqlsynthgen.base import FileUploader, TableGenerator
 from sqlsynthgen.settings import get_settings
-from sqlsynthgen.utils import create_db_engine, get_sync_engine
+from sqlsynthgen.utils import create_db_engine, get_sync_engine, logger
 
 Story = Generator[Tuple[str, dict[str, Any]], dict[str, Any], None]
 
@@ -49,9 +48,7 @@ def create_db_vocab(vocab_dict: Mapping[str, FileUploader]) -> None:
             try:
                 vocab_table.load(dst_conn)
             except IntegrityError:
-                logging.exception(
-                    "Loading the vocabulary table %s failed:", vocab_table
-                )
+                logger.exception("Loading the vocabulary table %s failed:", vocab_table)
 
 
 def create_db_data(
@@ -131,15 +128,19 @@ def populate(
     # Each story generator returns a python generator (an unfortunate naming clash with
     # what we call generators). Iterating over it yields individual rows for the
     # database. First, collect all of the python generators into a single list.
-    stories: list[Story] = sum(
+    stories: list[tuple[str, Story]] = sum(
         [
-            [sg["name"](dst_conn) for _ in range(sg["num_stories_per_pass"])]
+            [
+                (sg["name"], sg["function"](dst_conn))
+                for _ in range(sg["num_stories_per_pass"])
+            ]
             for sg in story_generator_list
         ],
         [],
     )
-    for story in stories:
+    for name, story in stories:
         # Run the inserts for each story within a transaction.
+        logger.debug("Generating data for story %s", name)
         with dst_conn.begin():
             _populate_story(story, table_dict, table_generator_dict, dst_conn)
 
@@ -150,6 +151,9 @@ def populate(
             # vocabulary table.
             continue
         table_generator = table_generator_dict[table.name]
+        if table_generator.num_rows_per_pass == 0:
+            continue
+        logger.debug("Generating data for table %s", table.name)
         # Run all the inserts for one table in a transaction
         with dst_conn.begin():
             for _ in range(table_generator.num_rows_per_pass):

--- a/sqlsynthgen/make.py
+++ b/sqlsynthgen/make.py
@@ -529,6 +529,7 @@ async def make_src_stats(
 
     async def execute_query(query_block: Mapping[str, Any]) -> Any:
         """Execute query in query_block."""
+        logger.debug("Executing query %s", query_block["name"])
         query = text(query_block["query"])
         if isinstance(engine, AsyncEngine):
             async with engine.connect() as conn:
@@ -539,6 +540,7 @@ async def make_src_stats(
 
         if "dp-query" in query_block:
             result_df = pd.DataFrame(raw_result.mappings())
+            logger.debug("Executing dp-query for %s", query_block["name"])
             dp_query = query_block["dp-query"]
             snsql_metadata = {"": {"": {"query_result": query_block["snsql-metadata"]}}}
             privacy = snsql.Privacy(

--- a/sqlsynthgen/remove.py
+++ b/sqlsynthgen/remove.py
@@ -4,7 +4,12 @@ from types import ModuleType
 from sqlalchemy import delete
 
 from sqlsynthgen.settings import get_settings
-from sqlsynthgen.utils import create_db_engine, get_orm_metadata, get_sync_engine
+from sqlsynthgen.utils import (
+    create_db_engine,
+    get_orm_metadata,
+    get_sync_engine,
+    logger,
+)
 
 
 def remove_db_data(
@@ -23,6 +28,7 @@ def remove_db_data(
         for table in reversed(metadata.sorted_tables):
             # We presume that all tables that aren't vocab should be truncated
             if table.name not in ssg_module.vocab_dict:
+                logger.debug("Truncating table %s", table.name)
                 dst_conn.execute(delete(table))
                 dst_conn.commit()
 
@@ -43,6 +49,7 @@ def remove_db_vocab(
         for table in reversed(metadata.sorted_tables):
             # We presume that all tables that are vocab should be truncated
             if table.name in ssg_module.vocab_dict:
+                logger.debug("Truncating vocabulary table %s", table.name)
                 dst_conn.execute(delete(table))
                 dst_conn.commit()
 

--- a/sqlsynthgen/templates/ssg.py.j2
+++ b/sqlsynthgen/templates/ssg.py.j2
@@ -81,8 +81,9 @@ def {{ gen_data.wrapper_name }}(dst_db_conn):
 story_generator_list = [
     {% for gen_data in story_generators %}
     {
-        "name": {{ gen_data.wrapper_name }},
+        "function": {{ gen_data.wrapper_name }},
         "num_stories_per_pass": {{ gen_data.num_stories_per_pass }},
+        "name": "{{ gen_data.function_call.function_name }}",
     },
     {% endfor %}
 ]

--- a/sqlsynthgen/unique_generator.py
+++ b/sqlsynthgen/unique_generator.py
@@ -1,8 +1,9 @@
 """Module for the UniqueGenerator class."""
-import logging
 from typing import Any, Callable, List, Optional, Set
 
 import sqlalchemy as sqla
+
+from sqlsynthgen.utils import logger
 
 
 class UniqueGenerator:
@@ -100,7 +101,7 @@ class UniqueGenerator:
                     # output of inner_generator. This means we can't guarantee enforcing
                     # the constraint.
                     enforceable = False
-                    logging.warning("Unenforceable unique constraint")
+                    logger.warning("Unenforceable unique constraint")
                     break
 
         for _ in range(self.max_tries):

--- a/sqlsynthgen/utils.py
+++ b/sqlsynthgen/utils.py
@@ -161,7 +161,7 @@ def warning_or_higher(record: logging.LogRecord) -> bool:
 
 def conf_logger(verbose: bool) -> None:
     """Configure the logger."""
-    global logger
+    # Note that this function modifies the global `logger`.
     level = logging.DEBUG if verbose else logging.INFO
     logger.setLevel(level)
     log_format = "%(message)s"

--- a/sqlsynthgen/utils.py
+++ b/sqlsynthgen/utils.py
@@ -143,8 +143,9 @@ def get_orm_metadata(
             metadata.remove(table)
     return metadata
 
+
 # This is the main logger that the other modules of sqlsynthgen should use for output.
-# conf_logger() should be called once, as early as possible, to configure this logger. 
+# conf_logger() should be called once, as early as possible, to configure this logger.
 logger = logging.getLogger(__name__)
 
 
@@ -164,7 +165,7 @@ def conf_logger(verbose: bool) -> None:
     level = logging.DEBUG if verbose else logging.INFO
     logger.setLevel(level)
     log_format = "%(message)s"
-    
+
     # info will always be printed to stdout
     # debug will be printed to stdout only if verbose=True
     stdout_handler = logging.StreamHandler(sys.stdout)

--- a/tests/examples/expected_ssg.py
+++ b/tests/examples/expected_ssg.py
@@ -214,15 +214,18 @@ def run_story_generators_long_story(dst_db_conn):
 
 story_generator_list = [
     {
-        "name": run_story_generators_short_story,
+        "function": run_story_generators_short_story,
         "num_stories_per_pass": 3,
+        "name": "story_generators.short_story",
     },
     {
-        "name": run_story_generators_full_row_story,
+        "function": run_story_generators_full_row_story,
         "num_stories_per_pass": 1,
+        "name": "story_generators.full_row_story",
     },
     {
-        "name": run_story_generators_long_story,
+        "function": run_story_generators_long_story,
         "num_stories_per_pass": 2,
+        "name": "story_generators.long_story",
     },
 ]

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -84,8 +84,9 @@ class MyTestCase(SSGTestCase):
                 story_generators: list[dict[str, Any]] = (
                     [
                         {
-                            "name": mock_story_gen,
+                            "function": mock_story_gen,
                             "num_stories_per_pass": num_stories_per_pass,
+                            "name": "mock_story_gen",
                         }
                     ]
                     if num_stories_per_pass > 0

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -152,9 +152,12 @@ class MyTestCase(SSGTestCase):
         mock_get_settings.return_value = get_test_settings()
 
         mock_load = MagicMock()
-        mock_vocab = MagicMock(spec=FileUploader)
-        mock_vocab.load = mock_load
-        vocab_list: dict[str, FileUploader] = {"table_name": mock_vocab}
+        mock_table = MagicMock()
+        mock_table.name = "Mock table"
+        mock_file_uploader = MagicMock(spec=FileUploader)
+        mock_file_uploader.load = mock_load
+        mock_file_uploader.table = mock_table
+        vocab_list: dict[str, FileUploader] = {mock_table.name: mock_file_uploader}
 
         create_db_vocab(vocab_list)
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -87,8 +87,7 @@ class DBFunctionalTestCase(RequiresDBTestCase):
             env=self.env,
         )
         self.assertEqual(
-            "WARNING: Table without PK detected. sqlsynthgen may not be able to "
-            "continue.\n",
+            "Table without PK detected. sqlsynthgen may not be able to continue.\n",
             completed_process.stderr.decode("utf-8"),
         )
         self.assertSuccess(completed_process)
@@ -104,15 +103,15 @@ class DBFunctionalTestCase(RequiresDBTestCase):
         # this could mean that we might accidentally violate the constraints. In
         # practice this won't happen because we only write one row to an empty table.
         self.assertEqual(
-            "WARNING:root:A unique constraint (ab_uniq) isn't fully covered by one "
+            "A unique constraint (ab_uniq) isn't fully covered by one "
             "row generator (['a']). Enforcement of the constraint may not work.\n"
-            "WARNING:root:A unique constraint (ab_uniq) isn't fully covered by one "
+            "A unique constraint (ab_uniq) isn't fully covered by one "
             "row generator (['b']). Enforcement of the constraint may not work.\n"
-            "WARNING:root:A unique constraint (abc_uniq2) isn't fully covered by one "
+            "A unique constraint (abc_uniq2) isn't fully covered by one "
             "row generator (['a']). Enforcement of the constraint may not work.\n"
-            "WARNING:root:A unique constraint (abc_uniq2) isn't fully covered by one "
+            "A unique constraint (abc_uniq2) isn't fully covered by one "
             "row generator (['b']). Enforcement of the constraint may not work.\n"
-            "WARNING:root:A unique constraint (abc_uniq2) isn't fully covered by one "
+            "A unique constraint (abc_uniq2) isn't fully covered by one "
             "row generator (['c']). Enforcement of the constraint may not work.\n",
             completed_process.stderr.decode("utf-8"),
         )
@@ -203,12 +202,11 @@ class DBFunctionalTestCase(RequiresDBTestCase):
             env=self.env,
         )
         self.assertEqual(
-            "WARNING:root:Table unignorable_table is supposed to be ignored but "
+            "Table unignorable_table is supposed to be ignored but "
             "there is a foreign key reference to it. "
             "You may need to create this table manually at the dst schema before "
             "running create-tables.\n"
-            "WARNING: Table without PK detected. "
-            "sqlsynthgen may not be able to continue.\n",
+            "Table without PK detected. sqlsynthgen may not be able to continue.\n",
             completed_process.stderr.decode("utf-8"),
         )
         self.assertSuccess(completed_process)
@@ -257,7 +255,18 @@ class DBFunctionalTestCase(RequiresDBTestCase):
         self.assertEqual("", completed_process.stderr.decode("utf-8"))
         self.assertSuccess(completed_process)
         self.assertEqual(
-            f"Making {self.alt_ssg_file_path}.\n{self.alt_ssg_file_path} created.\n",
+            f"Making {self.alt_ssg_file_path}.\n"
+            "Downloading vocabulary table empty_vocabulary\n"
+            "Done downloading empty_vocabulary\n"
+            "Downloading vocabulary table mitigation_type\n"
+            "Done downloading mitigation_type\n"
+            "Downloading vocabulary table ref_to_unignorable_table\n"
+            "Done downloading ref_to_unignorable_table\n"
+            "Downloading vocabulary table concept_type\n"
+            "Done downloading concept_type\n"
+            "Downloading vocabulary table concept\n"
+            "Done downloading concept\n"
+            f"{self.alt_ssg_file_path} created.\n",
             completed_process.stdout.decode("utf-8"),
         )
 
@@ -290,7 +299,7 @@ class DBFunctionalTestCase(RequiresDBTestCase):
             env=self.env,
         )
         self.assertEqual(
-            "WARNING:root:No rows in empty_vocabulary.yaml. Skipping...\n",
+            "No rows in empty_vocabulary.yaml. Skipping...\n",
             completed_process.stderr.decode("utf-8"),
         )
         self.assertSuccess(completed_process)
@@ -315,7 +324,34 @@ class DBFunctionalTestCase(RequiresDBTestCase):
         self.assertEqual("", completed_process.stderr.decode("utf-8"))
         self.assertSuccess(completed_process)
         self.assertEqual(
-            "Creating data.\nData created in 2 passes.\n",
+            "Creating data.\n"
+            "Generating data for story story_generators.short_story\n"
+            "Generating data for story story_generators.short_story\n"
+            "Generating data for story story_generators.short_story\n"
+            "Generating data for story story_generators.full_row_story\n"
+            "Generating data for story story_generators.long_story\n"
+            "Generating data for story story_generators.long_story\n"
+            "Generating data for table data_type_test\n"
+            "Generating data for table no_pk_test\n"
+            "Generating data for table person\n"
+            "Generating data for table unique_constraint_test\n"
+            "Generating data for table unique_constraint_test2\n"
+            "Generating data for table test_entity\n"
+            "Generating data for table hospital_visit\n"
+            "Generating data for story story_generators.short_story\n"
+            "Generating data for story story_generators.short_story\n"
+            "Generating data for story story_generators.short_story\n"
+            "Generating data for story story_generators.full_row_story\n"
+            "Generating data for story story_generators.long_story\n"
+            "Generating data for story story_generators.long_story\n"
+            "Generating data for table data_type_test\n"
+            "Generating data for table no_pk_test\n"
+            "Generating data for table person\n"
+            "Generating data for table unique_constraint_test\n"
+            "Generating data for table unique_constraint_test2\n"
+            "Generating data for table test_entity\n"
+            "Generating data for table hospital_visit\n"
+            "Data created in 2 passes.\n",
             completed_process.stdout.decode("utf-8"),
         )
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -234,7 +234,12 @@ class DBFunctionalTestCase(RequiresDBTestCase):
         self.assertEqual("", completed_process.stderr.decode("utf-8"))
         self.assertSuccess(completed_process)
         self.assertEqual(
-            f"Creating {self.stats_file_path}.\n{self.stats_file_path} created.\n",
+            f"Creating {self.stats_file_path}.\n"
+            "Executing query count_names\n"
+            "Executing query avg_person_id\n"
+            "Executing query count_opt_outs\n"
+            "Executing dp-query for count_opt_outs\n"
+            f"{self.stats_file_path} created.\n",
             completed_process.stdout.decode("utf-8"),
         )
 
@@ -304,7 +309,13 @@ class DBFunctionalTestCase(RequiresDBTestCase):
         )
         self.assertSuccess(completed_process)
         self.assertEqual(
-            "Loading vocab.\n5 tables loaded.\n",
+            "Loading vocab.\n"
+            "Loading vocabulary table empty_vocabulary\n"
+            "Loading vocabulary table mitigation_type\n"
+            "Loading vocabulary table ref_to_unignorable_table\n"
+            "Loading vocabulary table concept_type\n"
+            "Loading vocabulary table concept\n"
+            "5 tables loaded.\n",
             completed_process.stdout.decode("utf-8"),
         )
 
@@ -371,7 +382,15 @@ class DBFunctionalTestCase(RequiresDBTestCase):
         self.assertEqual("", completed_process.stderr.decode("utf-8"))
         self.assertSuccess(completed_process)
         self.assertEqual(
-            "Truncating non-vocabulary tables.\nNon-vocabulary tables truncated.\n",
+            "Truncating non-vocabulary tables.\n"
+            "Truncating table hospital_visit\n"
+            "Truncating table test_entity\n"
+            "Truncating table unique_constraint_test2\n"
+            "Truncating table unique_constraint_test\n"
+            "Truncating table person\n"
+            "Truncating table no_pk_test\n"
+            "Truncating table data_type_test\n"
+            "Non-vocabulary tables truncated.\n",
             completed_process.stdout.decode("utf-8"),
         )
 
@@ -391,7 +410,13 @@ class DBFunctionalTestCase(RequiresDBTestCase):
         self.assertEqual("", completed_process.stderr.decode("utf-8"))
         self.assertSuccess(completed_process)
         self.assertEqual(
-            "Truncating vocabulary tables.\nVocabulary tables truncated.\n",
+            "Truncating vocabulary tables.\n"
+            "Truncating vocabulary table concept\n"
+            "Truncating vocabulary table concept_type\n"
+            "Truncating vocabulary table ref_to_unignorable_table\n"
+            "Truncating vocabulary table mitigation_type\n"
+            "Truncating vocabulary table empty_vocabulary\n"
+            "Vocabulary tables truncated.\n",
             completed_process.stdout.decode("utf-8"),
         )
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -64,9 +64,9 @@ class TestCLI(SSGTestCase):
         self.assertSuccess(result)
 
     @patch("sqlsynthgen.main.Path")
-    @patch("sqlsynthgen.main.echo")
+    @patch("sqlsynthgen.main.logger")
     def test_make_generators_errors_if_file_exists(
-        self, mock_echo: MagicMock, mock_path: MagicMock
+        self, mock_logger: MagicMock, mock_path: MagicMock
     ) -> None:
         """Test the make-generators sub-command doesn't overwrite."""
 
@@ -80,14 +80,14 @@ class TestCLI(SSGTestCase):
             ],
             catch_exceptions=False,
         )
-        mock_echo.assert_called_once_with(
-            "ssg.py should not already exist. Exiting...", err=True
+        mock_logger.error.assert_called_once_with(
+            "%s should not already exist. Exiting...", mock_path.return_value
         )
         self.assertEqual(1, result.exit_code)
 
-    @patch("sqlsynthgen.main.echo")
+    @patch("sqlsynthgen.main.logger")
     def test_make_generators_errors_if_src_dsn_missing(
-        self, mock_echo: MagicMock
+        self, mock_logger: MagicMock
     ) -> None:
         """Test the make-generators sub-command with missing db params."""
         result = runner.invoke(
@@ -97,8 +97,8 @@ class TestCLI(SSGTestCase):
             ],
             catch_exceptions=False,
         )
-        mock_echo.assert_called_once_with(
-            "Missing source database connection details.", err=True
+        mock_logger.error.assert_called_once_with(
+            "Missing source database connection details."
         )
         self.assertEqual(1, result.exit_code)
 
@@ -217,9 +217,9 @@ class TestCLI(SSGTestCase):
         self.assertSuccess(result)
 
     @patch("sqlsynthgen.main.Path")
-    @patch("sqlsynthgen.main.echo")
+    @patch("sqlsynthgen.main.logger")
     def test_make_tables_errors_if_file_exists(
-        self, mock_echo: MagicMock, mock_path: MagicMock
+        self, mock_logger: MagicMock, mock_path: MagicMock
     ) -> None:
         """Test the make-tables sub-command doesn't overwrite."""
 
@@ -233,13 +233,15 @@ class TestCLI(SSGTestCase):
             ],
             catch_exceptions=False,
         )
-        mock_echo.assert_called_once_with(
-            "orm.py should not already exist. Exiting...", err=True
+        mock_logger.error.assert_called_once_with(
+            "%s should not already exist. Exiting...", mock_path.return_value
         )
         self.assertEqual(1, result.exit_code)
 
-    @patch("sqlsynthgen.main.echo")
-    def test_make_tables_errors_if_src_dsn_missing(self, mock_echo: MagicMock) -> None:
+    @patch("sqlsynthgen.main.logger")
+    def test_make_tables_errors_if_src_dsn_missing(
+        self, mock_logger: MagicMock
+    ) -> None:
         """Test the make-tables sub-command doesn't overwrite."""
 
         result = runner.invoke(
@@ -249,8 +251,8 @@ class TestCLI(SSGTestCase):
             ],
             catch_exceptions=False,
         )
-        mock_echo.assert_called_once_with(
-            "Missing source database connection details.", err=True
+        mock_logger.error.assert_called_once_with(
+            "Missing source database connection details."
         )
         self.assertEqual(1, result.exit_code)
 
@@ -318,9 +320,9 @@ class TestCLI(SSGTestCase):
         )
 
     @patch("sqlsynthgen.main.Path")
-    @patch("sqlsynthgen.main.echo")
+    @patch("sqlsynthgen.main.logger")
     def test_make_stats_errors_if_file_exists(
-        self, mock_echo: MagicMock, mock_path: MagicMock
+        self, mock_logger: MagicMock, mock_path: MagicMock
     ) -> None:
         """Test the make-stats sub-command when the stats file already exists."""
         mock_path.return_value.exists.return_value = True
@@ -337,16 +339,13 @@ class TestCLI(SSGTestCase):
             ],
             catch_exceptions=False,
         )
-        mock_echo.assert_called_once_with(
-            f"{output_path} should not already exist. Exiting...", err=True
+        mock_logger.error.assert_called_once_with(
+            "%s should not already exist. Exiting...", mock_path.return_value
         )
         self.assertEqual(1, result.exit_code)
 
-    @patch("sqlsynthgen.main.echo")
-    def test_make_stats_errors_if_no_src_dsn(
-        self,
-        mock_echo: MagicMock,
-    ) -> None:
+    @patch("sqlsynthgen.main.logger")
+    def test_make_stats_errors_if_no_src_dsn(self, mock_logger: MagicMock) -> None:
         """Test the make-stats sub-command with missing settings."""
         example_conf_path = "tests/examples/example_config.yaml"
 
@@ -358,8 +357,8 @@ class TestCLI(SSGTestCase):
             ],
             catch_exceptions=False,
         )
-        mock_echo.assert_called_once_with(
-            "Missing source database connection details.", err=True
+        mock_logger.error.assert_called_once_with(
+            "Missing source database connection details."
         )
         self.assertEqual(1, result.exit_code)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,6 @@
 """Tests for the utils module."""
 import os
 import sys
-from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
@@ -130,7 +129,8 @@ class TestReadConfig(SSGTestCase):
 
     def test_warns_of_invalid_config(self) -> None:
         """Test that we get a warning if the config is invalid."""
-        with patch("sys.stdout", new=StringIO()) as mock_stdout:
+        with patch("sqlsynthgen.utils.logger") as mock_logger:
             read_config_file("tests/examples/invalid_config.yaml")
-
-        self.assertIn("The config file is invalid:", mock_stdout.getvalue())
+            mock_logger.error.assert_called_with(
+                "The config file is invalid: %s", "'a' is not of type 'integer'"
+            )


### PR DESCRIPTION
Change to using the `logging` module exclusively for text output, instead of `print` and `echo`. The new set up is such that there is `logger` object in `utils`, and all log prints should happen by calling one of its methods. Warning, error, and critical level messages will always go to stderr, info always to stdout, and debug to stdout only if `--verbose` was chosen.

Using this, I've also added a lot of debug-level print outs, so that the user can get feedback on e.g. which table is being uploaded or which generator run if they choose `--verbose`.

~This builds on #141, and thus the diff is messy. Once that one is merged, reset the base to `main` to clean up the diff.~
Did the reset.