### PR TITLE
Add instructions for SQL Server

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -13,5 +13,7 @@ Which DBMSs does SqlSynthGen support?
 * SqlSynthGen most fully supports **PostgresSQL**, which it uses for its end-to-end functional tests.
 * SqlSynthGen also supports **MariaDB**, as long as you don't set ``use-asyncio: true`` in your config.
 * SqlSynthGen *might*, work with **SQLite** but this is largely untested.
+* SqlSynthGen may also work with SQL Server.
+  To connect to SQL Server, you will need to install `pyodbc <https://pypi.org/project/pyodbc/>`_ and an `ODBC driver <https://learn.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server?view=sql-server-ver16>`_, after which you should be able to use a DSN setting similar to ``SRC_DSN="mssql+pyodbc://username:password@hostname/dbname?driver=ODBC Driver 18 for SQL Server"``.
 
 Please open a GitHub issue if you would like to see support for another DBMS.


### PR DESCRIPTION
For a simple case (a table with a pk column and a varchar column), SSG works fine with SQL Server once you have installed the two extra dependencies (I'm not sure whether it's worth adding `pyodbc` to the Poetry requirements since you have to manually install the odbc drivers anyway).

There are SQL Server [images](https://hub.docker.com/_/microsoft-mssql-server), which we could use to add a functional test if we wanted.