### PR TITLE
Static builtin providers

### DIFF
--- a/sqlsynthgen/make.py
+++ b/sqlsynthgen/make.py
@@ -255,7 +255,7 @@ def _get_provider_for_column(column: Column) -> Tuple[list[str], str, list[str]]
             column_type,
             column.name,
         )
-    if column_size:
+    elif column_size:
         generator_arguments.append(str(column_size))
 
     return variable_names, generator_function, generator_arguments

--- a/sqlsynthgen/providers.py
+++ b/sqlsynthgen/providers.py
@@ -17,8 +17,9 @@ class ColumnValueProvider(BaseProvider):
 
         name = "column_value_provider"
 
+    @staticmethod
     def column_value(
-        self, db_connection: Connection, orm_class: Any, column_name: str
+        db_connection: Connection, orm_class: Any, column_name: str
     ) -> Any:
         """Return a random value from the column specified."""
         query = select(orm_class).order_by(functions.random()).limit(1)
@@ -50,8 +51,8 @@ class TimedeltaProvider(BaseProvider):
 
         name = "timedelta_provider"
 
+    @staticmethod
     def timedelta(
-        self,
         min_dt: dt.timedelta = dt.timedelta(seconds=0),
         # ints bigger than this cause trouble
         max_dt: dt.timedelta = dt.timedelta(seconds=2**32),
@@ -75,8 +76,8 @@ class TimespanProvider(BaseProvider):
 
         name = "timespan_provider"
 
+    @staticmethod
     def timespan(
-        self,
         earliest_start_year: int,
         last_start_year: int,
         min_dt: dt.timedelta = dt.timedelta(seconds=0),
@@ -194,6 +195,7 @@ class NullProvider(BaseProvider):
 
         name = "null_provider"
 
-    def null(self) -> None:
+    @staticmethod
+    def null() -> None:
         """Return `None`."""
         return None

--- a/tests/examples/example_orm.py
+++ b/tests/examples/example_orm.py
@@ -18,7 +18,7 @@ from sqlalchemy import (
     UniqueConstraint,
     Uuid,
 )
-from sqlalchemy.dialects.postgresql import CIDR
+from sqlalchemy.dialects.postgresql import BIT, CIDR
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 import datetime
 
@@ -78,6 +78,7 @@ class StrangeTypeTable(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     column_with_unusual_type: Mapped[Optional[Any]] = mapped_column(CIDR)
+    column_with_unusual_type_and_length: Mapped[Optional[Any]] = mapped_column(BIT(3))
 
 
 class UnignorableTable(Base):

--- a/tests/examples/expected_ssg.py
+++ b/tests/examples/expected_ssg.py
@@ -99,6 +99,7 @@ class strange_type_tableGenerator(TableGenerator):
     def __call__(self, dst_db_conn):
         result = {}
         result["column_with_unusual_type"] = generic.null_provider.null()
+        result["column_with_unusual_type_and_length"] = generic.null_provider.null()
         return result
 
 

--- a/tests/examples/src.dump
+++ b/tests/examples/src.dump
@@ -224,7 +224,8 @@ ALTER TABLE public.table_to_be_ignored OWNER TO postgres;
 
 CREATE TABLE public.strange_type_table (
     id integer NOT NULL,
-    column_with_unusual_type cidr
+    column_with_unusual_type cidr,
+    column_with_unusual_type_and_length bit(3)
 );
 
 ALTER TABLE public.strange_type_table OWNER TO postgres;

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -108,6 +108,11 @@ class DBFunctionalTestCase(RequiresDBTestCase):
             "for column column_with_unusual_type. "
             "Setting this column to NULL always, "
             "you may want to configure a row generator for it instead.\n"
+            "Unsupported SQLAlchemy type "
+            "<class 'sqlalchemy.dialects.postgresql.types.BIT'> "
+            "for column column_with_unusual_type_and_length. "
+            "Setting this column to NULL always, "
+            "you may want to configure a row generator for it instead.\n"
             "A unique constraint (ab_uniq) isn't fully covered by one "
             "row generator (['a']). Enforcement of the constraint may not work.\n"
             "A unique constraint (ab_uniq) isn't fully covered by one "
@@ -266,6 +271,11 @@ class DBFunctionalTestCase(RequiresDBTestCase):
             "Unsupported SQLAlchemy type "
             "<class 'sqlalchemy.dialects.postgresql.types.CIDR'> "
             "for column column_with_unusual_type. "
+            "Setting this column to NULL always, "
+            "you may want to configure a row generator for it instead.\n"
+            "Unsupported SQLAlchemy type "
+            "<class 'sqlalchemy.dialects.postgresql.types.BIT'> "
+            "for column column_with_unusual_type_and_length. "
             "Setting this column to NULL always, "
             "you may want to configure a row generator for it instead.\n",
             completed_process.stderr.decode("utf-8"),


### PR DESCRIPTION
- Check that we support unrecognised columns that have a size, such as `column_with_unusual_type_and_length bit(3)`
- Mark provider methods as `@staticmethod`s if they don't use `self`.